### PR TITLE
fix: add model.runCommand

### DIFF
--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -456,6 +456,13 @@ describe('XTerminalModel', () => {
 		expect(this.model.element.terminal.getSelection).toHaveBeenCalled()
 	})
 
+	it('runCommand(cmd)', () => {
+		this.model.element = this.element
+		const expectedText = 'some text'
+		this.model.runCommand(expectedText)
+		expect(this.model.element.ptyProcess.write.calls.allArgs()).toEqual([[expectedText + (process.platform === 'win32' ? '\r' : '\n')]])
+	})
+
 	it('pasteToTerminal(text)', () => {
 		this.model.element = this.element
 		const expectedText = 'some text'

--- a/src/model.js
+++ b/src/model.js
@@ -23,6 +23,7 @@ import { XTerminalProfilesSingleton } from './profiles'
 
 import fs from 'fs-extra'
 import path from 'path'
+import os from 'os'
 
 import { URL } from 'whatwg-url'
 
@@ -217,6 +218,10 @@ class XTerminalModel {
 
 	copyFromTerminal () {
 		return this.element.terminal.getSelection()
+	}
+
+	runCommand (cmd) {
+		this.pasteToTerminal(cmd + os.EOL.charAt(0))
 	}
 
 	pasteToTerminal (text) {

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -19,7 +19,6 @@
  */
 
 import { CompositeDisposable } from 'atom'
-import os from 'os'
 
 import { CONFIG_DATA } from './config'
 import { XTerminalElement } from './element'
@@ -282,7 +281,7 @@ class XTerminalSingleton {
 		)
 		await model.element.initializedPromise
 		for (const command of commands) {
-			model.pasteToTerminal(command + os.EOL)
+			model.runCommand(command)
 		}
 	}
 


### PR DESCRIPTION
Move the runCommand method to model to make it easier to run commands in the terminal.

This will make #20 and #21 really easy