### PR TITLE
feat: Add commands to insert/run selected text

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ text editor or on a terminal.
 Finally, terminal tabs are automatically reopened at the spot you placed them
 when you last exited Atom.
 
+## Active Terminal
+
+The active terminal is the terminal that will be used when sending commands to
+the terminal with commands like `x-terminal:insert-selected-text` and
+`x-terminal:run-selected-text`
+
+The active terminal will always have an astrix (`*`) in front of the title.
+By default when a terminal is hidden it becomes inactive and the last used
+visible terminal will become active. If there are no visible terminals none are
+active.
+
+The `Allow Hidden Terminal To Stay Active` setting will change the
+default behavior and keep a terminal that is hidden active until another
+terminal is focused.
+
 ## Organizing Terminals
 
 To quickly organize your terminal tabs, simply use the main menu. You can also

--- a/keymaps/x-terminal.json
+++ b/keymaps/x-terminal.json
@@ -10,7 +10,9 @@
     "ctrl-alt-shift-right": "x-terminal:open-split-right",
     "ctrl-alt-shift-i": "x-terminal:open-split-bottom-dock",
     "ctrl-alt-shift-u": "x-terminal:open-split-left-dock",
-    "ctrl-alt-shift-o": "x-terminal:open-split-right-dock"
+    "ctrl-alt-shift-o": "x-terminal:open-split-right-dock",
+    "ctrl-alt-r": "x-terminal:run-selected-text",
+    "ctrl-alt-i": "x-terminal:insert-selected-text"
   },
   ".platform-win32 atom-workspace": {
     "ctrl-`": "x-terminal:open",
@@ -23,7 +25,9 @@
     "ctrl-alt-shift-right": "x-terminal:open-split-right",
     "ctrl-alt-shift-i": "x-terminal:open-split-bottom-dock",
     "ctrl-alt-shift-u": "x-terminal:open-split-left-dock",
-    "ctrl-alt-shift-o": "x-terminal:open-split-right-dock"
+    "ctrl-alt-shift-o": "x-terminal:open-split-right-dock",
+    "ctrl-alt-r": "x-terminal:run-selected-text",
+    "ctrl-alt-i": "x-terminal:insert-selected-text"
   },
   ".platform-darwin atom-workspace": {
     "cmd-`": "x-terminal:open",
@@ -36,7 +40,9 @@
     "cmd-alt-shift-right": "x-terminal:open-split-right",
     "cmd-alt-shift-i": "x-terminal:open-split-bottom-dock",
     "cmd-alt-shift-u": "x-terminal:open-split-left-dock",
-    "cmd-alt-shift-o": "x-terminal:open-split-right-dock"
+    "cmd-alt-shift-o": "x-terminal:open-split-right-dock",
+    "cmd-alt-r": "x-terminal:run-selected-text",
+    "cmd-alt-i": "x-terminal:insert-selected-text"
   },
   ".platform-linux x-terminal": {
     "ctrl-insert": "x-terminal:copy",

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -323,6 +323,12 @@ describe('Call to colorBrightWhite()', () => {
 	})
 })
 
+describe('Call to allowHiddenToStayActive()', () => {
+	it('return false', () => {
+		expect(configDefaults.allowHiddenToStayActive).toBe(false)
+	})
+})
+
 describe('Call to leaveOpenAfterExit()', () => {
 	it('return true', () => {
 		expect(configDefaults.leaveOpenAfterExit).toBe(true)

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -1787,7 +1787,9 @@ describe('XTerminalElement', () => {
 
 	it('focusOnTerminal()', () => {
 		spyOn(this.element.terminal, 'focus')
+		spyOn(this.element.model, 'setActive')
 		this.element.focusOnTerminal()
+		expect(this.element.model.setActive).toHaveBeenCalled()
 		expect(this.element.terminal.focus).toHaveBeenCalled()
 	})
 

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -43,4 +43,67 @@ describe('Utilities', () => {
 		expect(hLine.classList.contains('x-terminal-profile-menu-element-hline')).toBe(true)
 		expect(hLine.textContent).toBe('.')
 	})
+
+	describe('recalculateActive()', () => {
+		const createTerminals = (num = 1) => {
+			const terminals = []
+			for (let i = 0; i < num; i++) {
+				terminals.push({
+					activeIndex: i,
+					isVisible () {},
+					emitter: {
+						emit () {},
+					},
+				})
+			}
+			return terminals
+		}
+
+		it('active first', () => {
+			const terminals = createTerminals(2)
+			const terminalsSet = new Set(terminals)
+			utils.recalculateActive(terminalsSet, terminals[1])
+			expect(terminals[0].activeIndex).toBe(1)
+			expect(terminals[1].activeIndex).toBe(0)
+		})
+
+		it('visible before hidden', () => {
+			const terminals = createTerminals(2)
+			const terminalsSet = new Set(terminals)
+			spyOn(terminals[1], 'isVisible').and.returnValue(true)
+			utils.recalculateActive(terminalsSet)
+			expect(terminals[0].activeIndex).toBe(1)
+			expect(terminals[1].activeIndex).toBe(0)
+		})
+
+		it('allowHiddenToStayActive', () => {
+			atom.config.set('x-terminal.terminalSettings.allowHiddenToStayActive', true)
+			const terminals = createTerminals(2)
+			const terminalsSet = new Set(terminals)
+			spyOn(terminals[1], 'isVisible').and.returnValue(true)
+			utils.recalculateActive(terminalsSet)
+			expect(terminals[0].activeIndex).toBe(0)
+			expect(terminals[1].activeIndex).toBe(1)
+		})
+
+		it('lower active index first', () => {
+			const terminals = createTerminals(2)
+			const terminalsSet = new Set(terminals)
+			terminals[0].activeIndex = 1
+			terminals[1].activeIndex = 0
+			utils.recalculateActive(terminalsSet)
+			expect(terminals[0].activeIndex).toBe(1)
+			expect(terminals[1].activeIndex).toBe(0)
+		})
+
+		it('emit did-change-title', () => {
+			const terminals = createTerminals(2)
+			const terminalsSet = new Set(terminals)
+			spyOn(terminals[0].emitter, 'emit')
+			spyOn(terminals[1].emitter, 'emit')
+			utils.recalculateActive(terminalsSet)
+			expect(terminals[0].emitter.emit).toHaveBeenCalledWith('did-change-title')
+			expect(terminals[1].emitter.emit).toHaveBeenCalledWith('did-change-title')
+		})
+	})
 })

--- a/spec/x-terminal-spec.js
+++ b/spec/x-terminal-spec.js
@@ -1,0 +1,48 @@
+/** @babel */
+
+import * as xTerminal from '../src/x-terminal'
+
+const xTerminalInstance = xTerminal.getInstance()
+
+describe('x-terminal', () => {
+	describe('getSelectedText()', () => {
+		it('returns selection', () => {
+			spyOn(atom.workspace, 'getActiveTextEditor').and.returnValue({
+				getSelectedText () {
+					return 'selection'
+				},
+			})
+			const selection = xTerminalInstance.getSelectedText()
+			expect(selection).toBe('selection')
+		})
+
+		it('returns removes newlines at the end', () => {
+			spyOn(atom.workspace, 'getActiveTextEditor').and.returnValue({
+				getSelectedText () {
+					return 'line1\r\nline2\r\n'
+				},
+			})
+			const selection = xTerminalInstance.getSelectedText()
+			expect(selection).toBe('line1\r\nline2')
+		})
+
+		it('returns entire line if nothing selected and moves down', () => {
+			const moveDown = jasmine.createSpy('moveDown')
+			spyOn(atom.workspace, 'getActiveTextEditor').and.returnValue({
+				getSelectedText () {
+					return ''
+				},
+				getCursorBufferPosition () {
+					return { row: 1, column: 1 }
+				},
+				lineTextForBufferRow (row) {
+					return `line${row}`
+				},
+				moveDown,
+			})
+			const selection = xTerminalInstance.getSelectedText()
+			expect(selection).toBe('line1')
+			expect(moveDown).toHaveBeenCalledWith(1)
+		})
+	})
+})

--- a/src/config.js
+++ b/src/config.js
@@ -62,6 +62,7 @@ export function resetConfigDefaults () {
 		colorBrightMagenta: '#ad7fa8',
 		colorBrightCyan: '#34e2e2',
 		colorBrightWhite: '#eeeeec',
+		allowHiddenToStayActive: false,
 		leaveOpenAfterExit: true,
 		allowRelaunchingTerminalsOnStartup: true,
 		relaunchTerminalOnStartup: true,
@@ -383,6 +384,12 @@ export const config = configOrder({
 					fromMenuSetting: (element, baseValue) => element.checked,
 					toMenuSetting: (val) => val,
 				},
+			},
+			allowHiddenToStayActive: {
+				title: 'Allow Hidden Terminal To Stay Active',
+				description: 'When an active terminal is hidden keep it active until another terminal is focused.',
+				type: 'boolean',
+				default: configDefaults.allowHiddenToStayActive,
 			},
 			leaveOpenAfterExit: {
 				title: 'Leave Open After Exit',

--- a/src/element.js
+++ b/src/element.js
@@ -704,6 +704,7 @@ class XTerminalElementImpl extends HTMLElement {
 
 	focusOnTerminal () {
 		if (this.terminal) {
+			this.model.setActive()
 			this.terminal.focus()
 		}
 	}

--- a/src/model.js
+++ b/src/model.js
@@ -48,6 +48,7 @@ class XTerminalModel {
 		this.profilesSingleton = XTerminalProfilesSingleton.instance
 		this.profile = this.profilesSingleton.createProfileDataFromUri(this.uri)
 		this.terminals_set = this.options.terminals_set
+		this.active = false
 		this.element = null
 		this.pane = null
 		this.title = DEFAULT_TITLE
@@ -228,6 +229,17 @@ class XTerminalModel {
 
 	pasteToTerminal (text) {
 		this.element.ptyProcess.write(text)
+	}
+
+	setActive () {
+		for (const terminal of this.terminals_set) {
+			terminal.active = false
+		}
+		this.active = true
+	}
+
+	isActive () {
+		return this.active
 	}
 
 	setNewPane (pane) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,3 +31,32 @@ export function createHorizontalLine () {
 	hLine.appendChild(document.createTextNode('.'))
 	return hLine
 }
+
+export function recalculateActive (terminalsSet, active) {
+	const allowHidden = atom.config.get('x-terminal.terminalSettings.allowHiddenToStayActive')
+	const terminals = [...terminalsSet]
+	terminals.sort((a, b) => {
+		// active before other
+		if (active && a === active) {
+			return -1
+		}
+		if (active && b === active) {
+			return 1
+		}
+		if (!allowHidden) {
+			// visible before hidden
+			if (a.isVisible() && !b.isVisible()) {
+				return -1
+			}
+			if (!a.isVisible() && b.isVisible()) {
+				return 1
+			}
+		}
+		// lower activeIndex before higher activeIndex
+		return a.activeIndex - b.activeIndex
+	})
+	terminals.forEach((t, i) => {
+		t.activeIndex = i
+		t.emitter.emit('did-change-title')
+	})
+}

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -253,6 +253,7 @@ class XTerminalSingleton {
 			if (cursor) {
 				const line = editor.lineTextForBufferRow(cursor.row)
 				selectedText = line
+				editor.moveDown(1)
 			}
 		}
 

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -171,6 +171,7 @@ class XTerminalSingleton {
 			'x-terminal:reorganize-left-dock': () => this.reorganize('left-dock'),
 			'x-terminal:reorganize-right-dock': () => this.reorganize('right-dock'),
 			'x-terminal:close-all': () => this.exitAllTerminals(),
+			'x-terminal:insert-selected-text': () => this.insertSelection(),
 		}))
 		this.disposables.add(atom.commands.add('x-terminal', {
 			'x-terminal:close': () => this.close(),
@@ -233,6 +234,41 @@ class XTerminalSingleton {
 	exitAllTerminals () {
 		for (const terminal of this.terminals_set) {
 			terminal.exit()
+		}
+	}
+
+	getSelectedText () {
+		const editor = atom.workspace.getActiveTextEditor()
+		if (!editor) {
+			return ''
+		}
+
+		let selectedText = ''
+		const selection = editor.getSelectedText()
+		if (selection) {
+			selectedText = selection
+		} else {
+			const cursor = editor.getCursorBufferPosition()
+			if (cursor) {
+				const line = editor.lineTextForBufferRow(cursor.row)
+				selectedText = line
+				editor.moveDown(1)
+			}
+		}
+
+		return selectedText
+	}
+
+	getActiveTerminal () {
+		const terminals = [...this.terminals_set]
+		return terminals.find(t => t.isActive())
+	}
+
+	insertSelection () {
+		const selection = this.getSelectedText()
+		const terminal = this.getActiveTerminal()
+		if (selection && terminal) {
+			terminal.pasteToTerminal(selection)
 		}
 	}
 

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -253,7 +253,6 @@ class XTerminalSingleton {
 			if (cursor) {
 				const line = editor.lineTextForBufferRow(cursor.row)
 				selectedText = line
-				editor.moveDown(1)
 			}
 		}
 

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -172,6 +172,7 @@ class XTerminalSingleton {
 			'x-terminal:reorganize-right-dock': () => this.reorganize('right-dock'),
 			'x-terminal:close-all': () => this.exitAllTerminals(),
 			'x-terminal:insert-selected-text': () => this.insertSelection(),
+			'x-terminal:run-selected-text': () => this.runSelection(),
 		}))
 		this.disposables.add(atom.commands.add('x-terminal', {
 			'x-terminal:close': () => this.close(),
@@ -269,6 +270,14 @@ class XTerminalSingleton {
 		const terminal = this.getActiveTerminal()
 		if (selection && terminal) {
 			terminal.pasteToTerminal(selection)
+		}
+	}
+
+	runSelection () {
+		const selection = this.getSelectedText()
+		const terminal = this.getActiveTerminal()
+		if (selection && terminal) {
+			terminal.runCommand(selection)
 		}
 	}
 

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -281,7 +281,7 @@ class XTerminalSingleton {
 		let selectedText = ''
 		const selection = editor.getSelectedText()
 		if (selection) {
-			selectedText = selection
+			selectedText = selection.replace(/[\r\n]+$/, '')
 		} else {
 			const cursor = editor.getCursorBufferPosition()
 			if (cursor) {
@@ -569,6 +569,10 @@ class XTerminalSingleton {
 }
 
 export { config } from './config'
+
+export function getInstance () {
+	return XTerminalSingleton.instance
+}
 
 export function activate (state) {
 	return XTerminalSingleton.instance.activate(state)


### PR DESCRIPTION
Add two commands
- `x-terminal:insert-selected-text`
- `x-terminal:run-selected-text`

The text comes from the selected text in a text editor or the line that the cursor is on if no text is selected.

The active terminal is the last focused terminal.

fixes #20

### TODO:
- [x] add keymaps
- [x] add tests
- [x] update docs