### PR TITLE
fix: remove NODE_ENV variable by default

### DIFF
--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -157,7 +157,7 @@ describe('Call to setEnv()', () => {
 
 describe('Call to deleteEnv()', () => {
 	it('return []', () => {
-		expect(configDefaults.deleteEnv).toBe('[]')
+		expect(configDefaults.deleteEnv).toBe('["NODE_ENV"]')
 	})
 })
 

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -236,7 +236,13 @@ describe('XTerminalElement', () => {
 	})
 
 	it('getEnv()', () => {
-		expect(JSON.stringify(this.element.getEnv())).toEqual(JSON.stringify(process.env))
+		const NODE_ENV = process.env.NODE_ENV
+		try {
+			delete process.env.NODE_ENV
+			expect(JSON.stringify(this.element.getEnv())).toEqual(JSON.stringify(process.env))
+		} finally {
+			process.env.NODE_ENV = NODE_ENV
+		}
 	})
 
 	it('getEnv() env set in uri', async () => {

--- a/spec/profiles-spec.js
+++ b/spec/profiles-spec.js
@@ -41,7 +41,7 @@ describe('XTerminalProfilesSingleton', () => {
 			projectCwd: true,
 			env: null,
 			setEnv: {},
-			deleteEnv: [],
+			deleteEnv: ['NODE_ENV'],
 			encoding: null,
 			fontSize: 14,
 			fontFamily: 'monospace',

--- a/src/config.js
+++ b/src/config.js
@@ -33,7 +33,7 @@ export function resetConfigDefaults () {
 		webLinks: true,
 		env: '',
 		setEnv: '{}',
-		deleteEnv: '[]',
+		deleteEnv: '["NODE_ENV"]',
 		encoding: '',
 		fontSize: 14,
 		// NOTE: Atom will crash if the font is set below 8.


### PR DESCRIPTION
Change the default for Environment Deletions setting changed from `[]` to `["NODE_ENV"]`

fixes #39 