### PR TITLE
feat: use getShellStartCommand to get the default command

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "semantic-release": "^17.1.1",
     "stylelint": "^13.6.1",
     "stylelint-config-standard": "^20.0.0",
-    "temp": "^0.9.1"
+    "temp": "^0.9.1",
+    "which": "^2.0.2"
   },
   "scripts": {
     "eslint": "eslint . --ext .json,.js",

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -39,23 +39,12 @@ describe('Call to shellCommand()', () => {
 		})
 	})
 
-	it('on win32 without COMSPEC set', () => {
+	it('on win32', () => {
 		Object.defineProperty(process, 'platform', {
 			value: 'win32',
 		})
-		if (process.env.COMSPEC) {
-			delete process.env.COMSPEC
-		}
-		expect(resetConfigDefaults().command).toBe('cmd.exe')
-	})
-
-	it('on win32 with COMSPEC set', () => {
-		Object.defineProperty(process, 'platform', {
-			value: 'win32',
-		})
-		const expected = 'somecommand.exe'
-		process.env.COMSPEC = expected
-		expect(resetConfigDefaults().command).toBe(expected)
+		const startCommand = resetConfigDefaults().command
+		expect(['pwsh.exe', 'powershell.exe', process.env.COMSPEC, 'cmd.exe'].includes(startCommand)).toBeTruthy()
 	})
 
 	it('on linux without SHELL set', () => {

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -20,7 +20,7 @@
  */
 
 import * as utils from '../src/utils'
-import childProcess from 'child_process'
+import which from 'which'
 
 describe('Utilities', () => {
 	it('clearDiv()', () => {
@@ -108,7 +108,7 @@ describe('Utilities', () => {
 		})
 	})
 
-	describe('getShellStartCommand()', () => {
+	describe('setShellStartCommand()', () => {
 		let mockPlatform, platform, COMSPEC, SHELL
 
 		beforeEach(function () {
@@ -132,64 +132,72 @@ describe('Utilities', () => {
 
 		it('windows pwsh.exe', async () => {
 			mockPlatform('win32')
-			spyOn(childProcess, 'spawn').and.callFake(() => {})
+			spyOn(which, 'which').and.callFake(() => {})
 
-			expect(utils.getShellStartCommand()).toBe('pwsh.exe')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toContain('pwsh.exe')
 		})
 
 		it('windows powershell.exe', async () => {
 			mockPlatform('win32')
-			spyOn(childProcess, 'spawn').and.callFake((cmd) => {
+			spyOn(which, 'which').and.callFake((cmd) => {
 				if (cmd === 'pwsh.exe') {
 					throw new Error()
 				}
 			})
 
-			expect(utils.getShellStartCommand()).toBe('powershell.exe')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toContain('powershell.exe')
 		})
 
 		it('windows env.COMSPEC', async () => {
 			mockPlatform('win32')
-			spyOn(childProcess, 'spawn').and.throwError()
+			spyOn(which, 'which').and.throwError()
 			process.env.COMSPEC = 'comspec'
 
-			expect(utils.getShellStartCommand()).toBe('comspec')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toBe('comspec')
 		})
 
 		it('windows no env.COMSPEC', async () => {
 			mockPlatform('win32')
-			spyOn(childProcess, 'spawn').and.throwError()
+			spyOn(which, 'which').and.throwError()
 			process.env.COMSPEC = ''
 
-			expect(utils.getShellStartCommand()).toBe('cmd.exe')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toContain('cmd.exe')
 		})
 
 		it('linux env.SHELL', async () => {
 			mockPlatform('linux')
 			process.env.SHELL = 'shell'
 
-			expect(utils.getShellStartCommand()).toBe('shell')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toBe('shell')
 		})
 
 		it('linux no env.SHELL', async () => {
 			mockPlatform('linux')
 			process.env.SHELL = ''
 
-			expect(utils.getShellStartCommand()).toBe('/bin/sh')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toBe('/bin/sh')
 		})
 
 		it('macos env.SHELL', async () => {
 			mockPlatform('darwin')
 			process.env.SHELL = 'shell'
 
-			expect(utils.getShellStartCommand()).toBe('shell')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toBe('shell')
 		})
 
 		it('macos no env.SHELL', async () => {
 			mockPlatform('darwin')
 			process.env.SHELL = ''
 
-			expect(utils.getShellStartCommand()).toBe('/bin/sh')
+			await utils.setShellStartCommand()
+			expect(atom.config.get('x-terminal.spawnPtySettings.command')).toBe('/bin/sh')
 		})
 	})
 })

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -20,6 +20,7 @@
  */
 
 import * as utils from '../src/utils'
+import childProcess from 'child_process'
 
 describe('Utilities', () => {
 	it('clearDiv()', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -21,11 +21,10 @@
 
 import os from 'os'
 import path from 'path'
-import { getShellStartCommand } from './utils'
 
 export function resetConfigDefaults () {
 	return {
-		command: getShellStartCommand(),
+		command: process.platform === 'win32' ? (process.env.COMSPEC || 'cmd.exe') : (process.env.SHELL || '/bin/sh'),
 		args: '[]',
 		termType: process.env.TERM || 'xterm-256color',
 		cwd: process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME,

--- a/src/config.js
+++ b/src/config.js
@@ -21,10 +21,11 @@
 
 import os from 'os'
 import path from 'path'
+import { getShellStartCommand } from './utils'
 
 export function resetConfigDefaults () {
 	return {
-		command: process.platform === 'win32' ? (process.env.COMSPEC || 'cmd.exe') : (process.env.SHELL || '/bin/sh'),
+		command: getShellStartCommand(),
 		args: '[]',
 		termType: process.env.TERM || 'xterm-256color',
 		cwd: process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME,

--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,7 @@ import path from 'path'
 export function resetConfigDefaults () {
 	return {
 		command: process.platform === 'win32' ? (process.env.COMSPEC || 'cmd.exe') : (process.env.SHELL || '/bin/sh'),
+		autoCommand: true,
 		args: '[]',
 		termType: process.env.TERM || 'xterm-256color',
 		cwd: process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME,
@@ -116,6 +117,21 @@ export const config = configOrder({
 					checkUrlParam: (val) => true,
 					toBaseProfile: (previousValue) => (atom.config.get('x-terminal.spawnPtySettings.command') || configDefaults.command),
 					fromMenuSetting: (element, baseValue) => (element.getModel().getText() || baseValue),
+					toMenuSetting: (val) => val,
+				},
+			},
+			autoCommand: {
+				title: 'Automatic shell start command',
+				description: 'Automatically detect the prefered shell start command in the next Atom restart. This will be switched off, if you edit `Command` configuration manually.',
+				type: 'boolean',
+				default: configDefaults.autoCommand,
+				profileData: {
+					defaultProfile: configDefaults.command,
+					toUrlParam: (val) => val,
+					fromUrlParam: (val) => val,
+					checkUrlParam: (val) => (val !== null && val !== ''),
+					toBaseProfile: (previousValue) => (atom.config.get('x-terminal.spawnPtySettings.autoCommand') || configDefaults.autoCommand),
+					fromMenuSetting: (element, baseValue) => element.checked,
 					toMenuSetting: (val) => val,
 				},
 			},

--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,7 @@ import path from 'path'
 export function resetConfigDefaults () {
 	return {
 		command: process.platform === 'win32' ? (process.env.COMSPEC || 'cmd.exe') : (process.env.SHELL || '/bin/sh'),
-		autoCommand: true,
+		autoCommand: false,
 		args: '[]',
 		termType: process.env.TERM || 'xterm-256color',
 		cwd: process.platform === 'win32' ? process.env.USERPROFILE : process.env.HOME,

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,7 +64,7 @@ export function recalculateActive (terminalsSet, active) {
 }
 
 // finds the default shell start commmand
-async function getShellStartCommand () {
+export async function getShellStartCommand () {
 	let shellStartCommand
 	if (process.platform === 'win32') {
 		// Windows
@@ -85,10 +85,4 @@ async function getShellStartCommand () {
 		shellStartCommand = process.env.SHELL || '/bin/sh'
 		return shellStartCommand
 	}
-}
-
-// set start command asyncronously
-export async function setShellStartCommand () {
-	const shellStartCommand = await getShellStartCommand()
-	atom.config.set('x-terminal.spawnPtySettings.command', shellStartCommand)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import childProcess from 'child_process'
+import { sync as whichSync } from 'which'
 
 export function clearDiv (div) {
 	while (div.firstChild) {
@@ -69,12 +69,10 @@ export function getShellStartCommand () {
 	if (process.platform === 'win32') {
 		// Windows
 		try {
-			childProcess.spawn('pwsh.exe', ['-v'])
-			shellStartCommand = 'pwsh.exe'
+			shellStartCommand = whichSync('pwsh.exe')
 		} catch (e1) {
 			try {
-				childProcess.spawn('powershell', ['-command', '(Get-Variable PSVersionTable -ValueOnly).PSVersion'])
-				shellStartCommand = 'powershell.exe'
+				shellStartCommand = whichSync('powershell.exe')
 			} catch (e2) {
 				shellStartCommand = process.env.COMSPEC || 'cmd.exe'
 			}

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { sync as whichSync } from 'which'
+import which from 'which'
 
 export function clearDiv (div) {
 	while (div.firstChild) {
@@ -64,22 +64,31 @@ export function recalculateActive (terminalsSet, active) {
 }
 
 // finds the default shell start commmand
-export function getShellStartCommand () {
+async function getShellStartCommand () {
 	let shellStartCommand
 	if (process.platform === 'win32') {
 		// Windows
 		try {
-			shellStartCommand = whichSync('pwsh.exe')
+			shellStartCommand = await which('pwsh.exe')
+			return shellStartCommand
 		} catch (e1) {
 			try {
-				shellStartCommand = whichSync('powershell.exe')
+				shellStartCommand = await which('powershell.exe')
+				return shellStartCommand
 			} catch (e2) {
 				shellStartCommand = process.env.COMSPEC || 'cmd.exe'
+				return shellStartCommand
 			}
 		}
 	} else {
 		// Unix
 		shellStartCommand = process.env.SHELL || '/bin/sh'
+		return shellStartCommand
 	}
-	return shellStartCommand
+}
+
+// set start command asyncronously
+export async function setShellStartCommand () {
+	const shellStartCommand = await getShellStartCommand()
+	atom.config.set('x-terminal.spawnPtySettings.command', shellStartCommand)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import childProcess from 'child_process'
+
 export function clearDiv (div) {
 	while (div.firstChild) {
 		div.removeChild(div.firstChild)
@@ -59,4 +61,27 @@ export function recalculateActive (terminalsSet, active) {
 		t.activeIndex = i
 		t.emitter.emit('did-change-title')
 	})
+}
+
+// finds the default shell start commmand
+export function getShellStartCommand () {
+	let shellStartCommand
+	if (process.platform === 'win32') {
+		// Windows
+		try {
+			childProcess.spawn('pwsh.exe', ['-v'])
+			shellStartCommand = 'pwsh.exe'
+		} catch (e1) {
+			try {
+				childProcess.spawn('powershell', ['-command', '(Get-Variable PSVersionTable -ValueOnly).PSVersion'])
+				shellStartCommand = 'powershell.exe'
+			} catch (e2) {
+				shellStartCommand = process.env.COMSPEC || 'cmd.exe'
+			}
+		}
+	} else {
+		// Unix
+		shellStartCommand = process.env.SHELL || '/bin/sh'
+	}
+	return shellStartCommand
 }

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -23,7 +23,7 @@
 import { CompositeDisposable } from 'atom'
 
 import { CONFIG_DATA } from './config'
-import { recalculateActive } from './utils'
+import { recalculateActive, setShellStartCommand } from './utils'
 import { XTerminalElement } from './element'
 import { XTerminalModel, isXTerminalModel } from './model'
 import { X_TERMINAL_BASE_URI, XTerminalProfilesSingleton } from './profiles'
@@ -55,6 +55,9 @@ class XTerminalSingleton {
 	}
 
 	activate (state) {
+		// set start command asyncronously
+		setShellStartCommand()
+
 		// Load profiles configuration.
 		this.profilesSingleton = XTerminalProfilesSingleton.instance
 

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -23,7 +23,7 @@
 import { CompositeDisposable } from 'atom'
 
 import { CONFIG_DATA } from './config'
-import { recalculateActive, setShellStartCommand } from './utils'
+import { recalculateActive, getShellStartCommand } from './utils'
 import { XTerminalElement } from './element'
 import { XTerminalModel, isXTerminalModel } from './model'
 import { X_TERMINAL_BASE_URI, XTerminalProfilesSingleton } from './profiles'
@@ -55,9 +55,6 @@ class XTerminalSingleton {
 	}
 
 	activate (state) {
-		// set start command asyncronously
-		setShellStartCommand()
-
 		// Load profiles configuration.
 		this.profilesSingleton = XTerminalProfilesSingleton.instance
 
@@ -67,6 +64,9 @@ class XTerminalSingleton {
 
 		// Disposables for this plugin.
 		this.disposables = new CompositeDisposable()
+
+		// set start command asyncronously
+		this.setShellStartCommand()
 
 		// Set holding all terminals available at any moment.
 		this.terminals_set = new Set()
@@ -568,6 +568,19 @@ class XTerminalSingleton {
 			activeItem = activeItem.getElement()
 			activeItem.focus()
 		}
+	}
+
+	// set start command asyncronously
+	async setShellStartCommand () {
+		if (atom.config.get('x-terminal.spawnPtySettings.autoCommand')) {
+			const shellStartCommand = await getShellStartCommand()
+			atom.config.set('x-terminal.spawnPtySettings.command', shellStartCommand)
+		}
+		this.disposables.add(
+			atom.config.observe('x-terminal.spawnPtySettings.command', () => {
+				atom.config.set('x-terminal.spawnPtySettings.autoCommand', false)
+			}),
+		)
 	}
 }
 


### PR DESCRIPTION
On Windows, as the default value for the config, this uses pwsh (PowerShellCore) if available on a system.  If not it will use powershell, and in the end, it will use cmd.

