### PR TITLE
feat: add x-terminal:unfocus command

### DIFF
--- a/keymaps/x-terminal.json
+++ b/keymaps/x-terminal.json
@@ -48,13 +48,15 @@
     "ctrl-insert": "x-terminal:copy",
     "ctrl-shift-c": "x-terminal:copy",
     "shift-insert": "x-terminal:paste",
-    "ctrl-shift-v": "x-terminal:paste"
+    "ctrl-shift-v": "x-terminal:paste",
+    "ctrl-shift-u": "x-terminal:unfocus"
   },
   ".platform-win32 x-terminal": {
     "ctrl-insert": "x-terminal:copy",
     "ctrl-shift-c": "x-terminal:copy",
     "shift-insert": "x-terminal:paste",
-    "ctrl-shift-v": "x-terminal:paste"
+    "ctrl-shift-v": "x-terminal:paste",
+    "ctrl-shift-u": "x-terminal:unfocus"
   },
   ".platform-darwin x-terminal": {
     "ctrl-shift-c": "x-terminal:copy",
@@ -62,6 +64,7 @@
     "ctrl-shift-v": "x-terminal:paste",
     "shift-insert": "x-terminal:paste",
     "cmd-c": "x-terminal:copy",
-    "cmd-v": "x-terminal:paste"
+    "cmd-v": "x-terminal:paste",
+    "ctrl-shift-u": "x-terminal:unfocus"
   }
 }

--- a/spec/custom-runner.js
+++ b/spec/custom-runner.js
@@ -21,7 +21,12 @@
 
 import { createRunner } from 'atom-jasmine3-test-runner'
 
-module.exports = createRunner({}, () => {
+module.exports = createRunner({
+	specHelper: {
+		attachToDom: true,
+		customMatchers: true,
+	},
+}, () => {
 	// eslint-disable-next-line no-console
 	const warn = console.warn.bind(console)
 	beforeEach(() => {

--- a/spec/x-terminal-spec.js
+++ b/spec/x-terminal-spec.js
@@ -45,4 +45,18 @@ describe('x-terminal', () => {
 			expect(moveDown).toHaveBeenCalledWith(1)
 		})
 	})
+
+	describe('unfocus()', () => {
+		it('focuses atom-workspace', async () => {
+			jasmine.attachToDOM(atom.views.getView(atom.workspace))
+			await xTerminalInstance.activate()
+			const model = await xTerminalInstance.openInCenterOrDock(atom.workspace)
+			await model.initializedPromise
+			await model.element.createTerminal()
+
+			expect(model.element).toHaveFocus()
+			xTerminalInstance.unfocus()
+			expect(model.element).not.toHaveFocus()
+		})
+	})
 })

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -212,6 +212,7 @@ class XTerminalSingleton {
 				'x-terminal:restart': () => this.restart(),
 				'x-terminal:copy': () => this.copy(),
 				'x-terminal:paste': () => this.paste(),
+				'x-terminal:unfocus': () => this.unfocus(),
 			}),
 		)
 	}
@@ -355,14 +356,22 @@ class XTerminalSingleton {
 	 * @return {XTerminalModel} Instance of XTerminalModel.
 	 */
 	async runCommands (commands) {
-		const options = this.addDefaultPosition()
-		const model = await this.open(
-			XTerminalProfilesSingleton.instance.generateNewUri(),
-			options,
-		)
-		await model.element.initializedPromise
+		let terminal
+		if (atom.config.get('x-terminal.terminalSettings.runInActive')) {
+			terminal = this.getActiveTerminal()
+		}
+
+		if (!terminal) {
+			const options = this.addDefaultPosition()
+			terminal = await this.open(
+				XTerminalProfilesSingleton.instance.generateNewUri(),
+				options,
+			)
+		}
+
+		await terminal.element.initializedPromise
 		for (const command of commands) {
-			model.runCommand(command)
+			terminal.runCommand(command)
 		}
 	}
 
@@ -496,6 +505,10 @@ class XTerminalSingleton {
 
 	paste () {
 		this.performOperationOnItem('paste')
+	}
+
+	unfocus () {
+		atom.views.getView(atom.workspace).focus()
 	}
 
 	toggleProfileMenu () {


### PR DESCRIPTION
Add the command `x-terminal:unfocus` to unfocus the active terminal so shortcut keys can be used outside of x-terminal.

Map the shortcut <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>U</kbd> to the `x-terminal:unfocus` command on all platforms.

fixes #140 