### PR TITLE
feat: add context-menu items to tree view and tabs

### DIFF
--- a/menus/x-terminal.json
+++ b/menus/x-terminal.json
@@ -76,12 +76,12 @@
         "command": "x-terminal:close-all"
       }
     ],
-    "atom-text-editor": [{
+    "atom-text-editor, .tree-view, .tab-bar": [{
       "label": "X Terminal",
       "submenu": [
         {
           "label": "Open New Terminal",
-          "command": "x-terminal:open"
+          "command": "x-terminal:open-context-menu"
         },
         {
           "label": "Focus On Terminal",
@@ -89,31 +89,31 @@
         },
         {
           "label": "Open New Terminal (Split Up)",
-          "command": "x-terminal:open-split-up"
+          "command": "x-terminal:open-split-up-context-menu"
         },
         {
           "label": "Open New Terminal (Split Down)",
-          "command": "x-terminal:open-split-down"
+          "command": "x-terminal:open-split-down-context-menu"
         },
         {
           "label": "Open New Terminal (Split Left)",
-          "command": "x-terminal:open-split-left"
+          "command": "x-terminal:open-split-left-context-menu"
         },
         {
           "label": "Open New Terminal (Split Right)",
-          "command": "x-terminal:open-split-right"
+          "command": "x-terminal:open-split-right-context-menu"
         },
         {
           "label": "Open New Terminal (Bottom Dock)",
-          "command": "x-terminal:open-split-bottom-dock"
+          "command": "x-terminal:open-split-bottom-dock-context-menu"
         },
         {
           "label": "Open New Terminal (Left Dock)",
-          "command": "x-terminal:open-split-left-dock"
+          "command": "x-terminal:open-split-left-dock-context-menu"
         },
         {
           "label": "Open New Terminal (Right Dock)",
-          "command": "x-terminal:open-split-right-dock"
+          "command": "x-terminal:open-split-right-dock-context-menu"
         },
         {
           "label": "Reorganize Terminal Tabs (Current Pane)",

--- a/src/config.js
+++ b/src/config.js
@@ -169,7 +169,7 @@ export const config = configOrder({
 			},
 			projectCwd: {
 				title: 'Use Project Directory',
-				description: 'Use the first project directory when launching command.',
+				description: 'Use project directory if cwd is in a project when launching command.',
 				type: 'boolean',
 				default: configDefaults.projectCwd,
 				profileData: {

--- a/src/model.js
+++ b/src/model.js
@@ -71,18 +71,27 @@ class XTerminalModel {
 	}
 
 	async initialize () {
+		let cwd
+
+		if (this.options.target) {
+			cwd = this.options.target
+		} else if (this.profile.projectCwd) {
+			const previousActiveItem = atom.workspace.getActivePaneItem()
+			if (typeof previousActiveItem !== 'undefined' && typeof previousActiveItem.getPath === 'function') {
+				cwd = previousActiveItem.getPath()
+				const dir = atom.project.relativizePath(cwd)[0]
+				if (dir) {
+					this.profile.cwd = dir
+					return
+				}
+			} else {
+				cwd = atom.project.getPaths()[0]
+			}
+		} else {
+			cwd = this.profile.cwd
+		}
+
 		const baseProfile = this.profilesSingleton.getBaseProfile()
-		const previousActiveItem = atom.workspace.getActivePaneItem()
-		let cwd = this.profile.projectCwd ? atom.project.getPaths()[0] : this.profile.cwd
-		if (typeof previousActiveItem !== 'undefined' && typeof previousActiveItem.getPath === 'function') {
-			cwd = previousActiveItem.getPath()
-		}
-		const dir = atom.project.relativizePath(cwd)[0]
-		if (dir) {
-			// Use project paths whenever they are available by default.
-			this.profile.cwd = dir
-			return
-		}
 		if (!cwd) {
 			this.profile.cwd = baseProfile.cwd
 			return

--- a/src/x-terminal.js
+++ b/src/x-terminal.js
@@ -212,6 +212,71 @@ class XTerminalSingleton {
 				'x-terminal:run-selected-text': () => this.runSelection(),
 				'x-terminal:focus': () => this.focus(),
 			}),
+			atom.commands.add('atom-text-editor, .tree-view, .tab-bar', {
+				'x-terminal:open-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.open(
+						this.profilesSingleton.generateNewUri(),
+						this.addDefaultPosition({ target }),
+					),
+				},
+				'x-terminal:open-center-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.openInCenterOrDock(
+						atom.workspace,
+						{ target },
+					),
+				},
+				'x-terminal:open-split-up-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.open(
+						this.profilesSingleton.generateNewUri(),
+						{ split: 'up', target },
+					),
+				},
+				'x-terminal:open-split-down-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.open(
+						this.profilesSingleton.generateNewUri(),
+						{ split: 'down', target },
+					),
+				},
+				'x-terminal:open-split-left-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.open(
+						this.profilesSingleton.generateNewUri(),
+						{ split: 'left', target },
+					),
+				},
+				'x-terminal:open-split-right-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.open(
+						this.profilesSingleton.generateNewUri(),
+						{ split: 'right', target },
+					),
+				},
+				'x-terminal:open-split-bottom-dock-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.openInCenterOrDock(
+						atom.workspace.getBottomDock(),
+						{ target },
+					),
+				},
+				'x-terminal:open-split-left-dock-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.openInCenterOrDock(
+						atom.workspace.getLeftDock(),
+						{ target },
+					),
+				},
+				'x-terminal:open-split-right-dock-context-menu': {
+					hiddenInCommandPalette: true,
+					didDispatch: ({ target }) => this.openInCenterOrDock(
+						atom.workspace.getRightDock(),
+						{ target },
+					),
+				},
+			}),
 			atom.commands.add('x-terminal', {
 				'x-terminal:close': () => this.close(),
 				'x-terminal:restart': () => this.restart(),
@@ -256,6 +321,48 @@ class XTerminalSingleton {
 			this.profilesSingleton.generateNewUri(),
 			options,
 		)
+	}
+
+	getPath (target) {
+		if (!target) {
+			const paths = atom.project.getPaths()
+			if (paths && paths.length > 0) {
+				return paths[0]
+			}
+			return null
+		}
+
+		const treeView = target.closest('.tree-view')
+		if (treeView) {
+			// called from treeview
+			const selected = treeView.querySelector('.selected > .list-item > .name, .selected > .name')
+			if (selected) {
+				return selected.dataset.path
+			}
+			return null
+		}
+
+		const tab = target.closest('.tab-bar > .tab')
+		if (tab) {
+			// called from tab
+			const title = tab.querySelector('.title')
+			if (title && title.dataset.path) {
+				return title.dataset.path
+			}
+			return null
+		}
+
+		const textEditor = target.closest('atom-text-editor')
+		if (textEditor && typeof textEditor.getModel === 'function') {
+			// called from atom-text-editor
+			const model = textEditor.getModel()
+			if (model && typeof model.getPath === 'function') {
+				return model.getPath()
+			}
+			return null
+		}
+
+		return null
 	}
 
 	refitAllTerminals () {


### PR DESCRIPTION
Adds context menu items to tree-view and tab-bar. When executing from tree-view or tab bar opens terminal in folder of selected item.

This will be a breaking change with the way we determine cwd.

fixes #212 
fixes #96