### PR TITLE
feat: add x-terminal:clear command

### DIFF
--- a/keymaps/x-terminal.json
+++ b/keymaps/x-terminal.json
@@ -49,14 +49,16 @@
     "ctrl-shift-c": "x-terminal:copy",
     "shift-insert": "x-terminal:paste",
     "ctrl-shift-v": "x-terminal:paste",
-    "ctrl-shift-u": "x-terminal:unfocus"
+    "ctrl-shift-u": "x-terminal:unfocus",
+    "ctrl-l": "x-terminal:clear"
   },
   ".platform-win32 x-terminal": {
     "ctrl-insert": "x-terminal:copy",
     "ctrl-shift-c": "x-terminal:copy",
     "shift-insert": "x-terminal:paste",
     "ctrl-shift-v": "x-terminal:paste",
-    "ctrl-shift-u": "x-terminal:unfocus"
+    "ctrl-shift-u": "x-terminal:unfocus",
+    "ctrl-l": "x-terminal:clear"
   },
   ".platform-darwin x-terminal": {
     "ctrl-shift-c": "x-terminal:copy",
@@ -65,6 +67,7 @@
     "shift-insert": "x-terminal:paste",
     "cmd-c": "x-terminal:copy",
     "cmd-v": "x-terminal:paste",
-    "ctrl-shift-u": "x-terminal:unfocus"
+    "ctrl-shift-u": "x-terminal:unfocus",
+    "ctrl-l": "x-terminal:clear"
   }
 }

--- a/menus/x-terminal.json
+++ b/menus/x-terminal.json
@@ -18,6 +18,10 @@
         "command": "x-terminal:restart"
       },
       {
+        "label": "Clear",
+        "command": "x-terminal:clear"
+      },
+      {
         "type": "separator"
       },
       {

--- a/spec/delete-profile-element-spec.js
+++ b/spec/delete-profile-element-spec.js
@@ -22,21 +22,21 @@
 import { XTerminalDeleteProfileElement } from '../src/delete-profile-element'
 
 describe('XTerminalDeleteProfileElement', () => {
-	this.model = null
+	let model
 
 	beforeEach(() => {
-		this.model = jasmine.createSpyObj('model', ['setElement'])
+		model = jasmine.createSpyObj('model', ['setElement'])
 	})
 
 	it('initialize()', () => {
 		const element = new XTerminalDeleteProfileElement()
-		element.initialize(this.model)
+		element.initialize(model)
 		expect(element.promptButtonsDiv.childElementCount).toBe(0)
 	})
 
 	it('setNewPrompt()', () => {
 		const element = new XTerminalDeleteProfileElement()
-		element.initialize(this.model)
+		element.initialize(model)
 		const profileName = 'foo'
 		const confirmHandler = () => {}
 		const cancelHandler = () => {}

--- a/spec/delete-profile-model-spec.js
+++ b/spec/delete-profile-model-spec.js
@@ -22,38 +22,38 @@
 import { XTerminalDeleteProfileModel } from '../src/delete-profile-model'
 
 describe('XTerminalDeleteProfileModel', () => {
-	this.atomXtermProfileMenuElement = null
+	let atomXtermProfileMenuElement
 
 	beforeEach(() => {
-		this.atomXtermProfileMenuElement = jasmine.createSpy(
+		atomXtermProfileMenuElement = jasmine.createSpy(
 			'atomXtermProfileMenuElement',
 		)
 	})
 
 	it('constructor()', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		expect(model).not.toBeNull()
 	})
 
 	it('getTitle()', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		expect(model.getTitle()).toBe('X Terminal Delete Profile Model')
 	})
 
 	it('getElement()', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		expect(model.getElement()).toBeNull()
 	})
 
 	it('setElement()', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		const element = jasmine.createSpy('atomXtermDeleteProfileElement')
 		model.setElement(element)
 		expect(model.getElement()).toBe(element)
 	})
 
 	it('close() panel is not visible', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(false)
 		model.close()
@@ -61,7 +61,7 @@ describe('XTerminalDeleteProfileModel', () => {
 	})
 
 	it('close() panel is visible', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.close()
@@ -69,7 +69,7 @@ describe('XTerminalDeleteProfileModel', () => {
 	})
 
 	it('promptDelete() panel is shown', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['show', 'isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.element = jasmine.createSpyObj('atomXtermDeleteProfileElement', ['setNewPrompt'])
@@ -78,7 +78,7 @@ describe('XTerminalDeleteProfileModel', () => {
 	})
 
 	it('promptDelete() new prompt is set', () => {
-		const model = new XTerminalDeleteProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalDeleteProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['show', 'isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.element = jasmine.createSpyObj('atomXtermDeleteProfileElement', ['setNewPrompt'])

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -2247,6 +2247,12 @@ describe('XTerminalElement', () => {
 		expect(element.getXtermOptions()).toEqual(expected)
 	})
 
+	it('clear terminal', () => {
+		spyOn(element.terminal, 'clear')
+		element.clear()
+		expect(element.terminal.clear).toHaveBeenCalled()
+	})
+
 	it('applyPendingTerminalProfileOptions() terminal not visible', () => {
 		spyOn(element, 'refitTerminal')
 		element.terminalDivInitiallyVisible = false

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -33,25 +33,24 @@ import { URL, URLSearchParams } from 'whatwg-url'
 
 temp.track()
 
-describe('XTerminalElement', () => {
-	const savedPlatform = process.platform
-	this.element = null
-	this.tmpdir = null
+async function createNewElement (uri = 'x-terminal://somesessionid/') {
+	const terminalsSet = new Set()
+	const model = new XTerminalModel({
+		uri: uri,
+		terminals_set: terminalsSet,
+	})
+	await model.initializedPromise
+	model.pane = jasmine.createSpyObj('pane',
+		['removeItem', 'getActiveItem', 'destroyItem'])
+	const element = new XTerminalElement()
+	await element.initialize(model)
+	await element.createTerminal()
+	return element
+}
 
-	const createNewElement = async (uri = 'x-terminal://somesessionid/') => {
-		const terminalsSet = new Set()
-		const model = new XTerminalModel({
-			uri: uri,
-			terminals_set: terminalsSet,
-		})
-		await model.initializedPromise
-		model.pane = jasmine.createSpyObj('pane',
-			['removeItem', 'getActiveItem', 'destroyItem'])
-		const element = new XTerminalElement()
-		await element.initialize(model)
-		await element.createTerminal()
-		return element
-	}
+describe('XTerminalElement', () => {
+	let element, tmpdir
+	const savedPlatform = process.platform
 
 	beforeEach(async () => {
 		atom.config.clear()
@@ -62,13 +61,12 @@ describe('XTerminalElement', () => {
 			.and.returnValue('sometestprocess')
 		spyOn(nodePty, 'spawn').and.returnValue(ptyProcess)
 		spyOn(shell, 'openExternal')
-		const element = await createNewElement()
-		this.element = element
-		this.tmpdir = await temp.mkdir()
+		element = await createNewElement()
+		tmpdir = await temp.mkdir()
 	})
 
 	afterEach(async () => {
-		this.element.destroy()
+		element.destroy()
 		Object.defineProperty(process, 'platform', {
 			value: savedPlatform,
 		})
@@ -78,32 +76,32 @@ describe('XTerminalElement', () => {
 
 	it('initialize(model)', () => {
 		// Simply test if the terminal has been created.
-		expect(this.element.terminal).toBeTruthy()
+		expect(element.terminal).toBeTruthy()
 	})
 
 	it('initialize(model) check session-id', () => {
-		expect(this.element.getAttribute('session-id')).toBe('somesessionid')
+		expect(element.getAttribute('session-id')).toBe('somesessionid')
 	})
 
 	it('destroy() check ptyProcess killed', () => {
-		this.element.destroy()
-		expect(this.element.ptyProcess.kill).toHaveBeenCalled()
+		element.destroy()
+		expect(element.ptyProcess.kill).toHaveBeenCalled()
 	})
 
 	it('destroy() check terminal destroyed', () => {
-		spyOn(this.element.terminal, 'dispose').and.callThrough()
-		this.element.destroy()
-		expect(this.element.terminal.dispose).toHaveBeenCalled()
+		spyOn(element.terminal, 'dispose').and.callThrough()
+		element.destroy()
+		expect(element.terminal.dispose).toHaveBeenCalled()
 	})
 
 	it('destroy() check disposables disposed', () => {
-		spyOn(this.element.disposables, 'dispose').and.callThrough()
-		this.element.destroy()
-		expect(this.element.disposables.dispose).toHaveBeenCalled()
+		spyOn(element.disposables, 'dispose').and.callThrough()
+		element.destroy()
+		expect(element.disposables.dispose).toHaveBeenCalled()
 	})
 
 	it('getShellCommand()', () => {
-		expect(this.element.getShellCommand()).toBe(configDefaults.command)
+		expect(element.getShellCommand()).toBe(configDefaults.command)
 	})
 
 	it('getShellCommand() command set in uri', async () => {
@@ -115,7 +113,7 @@ describe('XTerminalElement', () => {
 	})
 
 	it('getArgs()', () => {
-		expect(this.element.getArgs()).toEqual([])
+		expect(element.getArgs()).toEqual([])
 	})
 
 	it('getArgs() args set in uri', async () => {
@@ -127,12 +125,12 @@ describe('XTerminalElement', () => {
 	})
 
 	it('getArgs() throw exception when args is not an array', () => {
-		this.element.model.profile.args = {}
-		expect(() => { this.element.getArgs() }).toThrow(new Error('Arguments set are not an array.'))
+		element.model.profile.args = {}
+		expect(() => { element.getArgs() }).toThrow(new Error('Arguments set are not an array.'))
 	})
 
 	it('getTermType()', () => {
-		expect(this.element.getTermType()).toBe(configDefaults.termType)
+		expect(element.getTermType()).toBe(configDefaults.termType)
 	})
 
 	it('getTermType() name set in uri', async () => {
@@ -144,37 +142,37 @@ describe('XTerminalElement', () => {
 	})
 
 	it('checkPathIsDirectory() no path given', async () => {
-		const isDirectory = await this.element.checkPathIsDirectory()
+		const isDirectory = await element.checkPathIsDirectory()
 		expect(isDirectory).toBe(false)
 	})
 
 	it('checkPathIsDirectory() path set to undefined', async () => {
-		const isDirectory = await this.element.checkPathIsDirectory(undefined)
+		const isDirectory = await element.checkPathIsDirectory(undefined)
 		expect(isDirectory).toBe(false)
 	})
 
 	it('checkPathIsDirectory() path set to null', async () => {
-		const isDirectory = await this.element.checkPathIsDirectory(null)
+		const isDirectory = await element.checkPathIsDirectory(null)
 		expect(isDirectory).toBe(false)
 	})
 
 	it('checkPathIsDirectory() path set to tmpdir', async () => {
-		const isDirectory = await this.element.checkPathIsDirectory(this.tmpdir)
+		const isDirectory = await element.checkPathIsDirectory(tmpdir)
 		expect(isDirectory).toBe(true)
 	})
 
 	it('checkPathIsDirectory() path set to non-existent dir', async () => {
-		const isDirectory = await this.element.checkPathIsDirectory(path.join(this.tmpdir, 'non-existent-dir'))
+		const isDirectory = await element.checkPathIsDirectory(path.join(tmpdir, 'non-existent-dir'))
 		expect(isDirectory).toBe(false)
 	})
 
 	it('getCwd()', async () => {
-		const cwd = await this.element.getCwd()
+		const cwd = await element.getCwd()
 		expect(cwd).toBe(configDefaults.cwd)
 	})
 
 	it('getCwd() cwd set in uri', async () => {
-		const expected = this.tmpdir
+		const expected = tmpdir
 		const params = new URLSearchParams({ cwd: expected })
 		const url = new URL('x-terminal://?' + params.toString())
 		const element = await createNewElement(url.href)
@@ -185,7 +183,7 @@ describe('XTerminalElement', () => {
 	it('getCwd() ignore cwd in uri if projectCwd is set', async () => {
 		const expected = await temp.mkdir('projectCwd')
 		spyOn(atom.project, 'getPaths').and.returnValue([expected])
-		const params = new URLSearchParams({ projectCwd: true, cwd: this.tmpdir })
+		const params = new URLSearchParams({ projectCwd: true, cwd: tmpdir })
 		const url = new URL('x-terminal://?' + params.toString())
 		const element = await createNewElement(url.href)
 		const cwd = await element.getCwd()
@@ -197,13 +195,13 @@ describe('XTerminalElement', () => {
 			'previousActiveItem',
 			['getPath'],
 		)
-		previousActiveItem.getPath.and.returnValue(this.tmpdir)
+		previousActiveItem.getPath.and.returnValue(tmpdir)
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(
 			previousActiveItem,
 		)
 		const element = await createNewElement()
 		const cwd = await element.getCwd()
-		expect(cwd).toBe(this.tmpdir)
+		expect(cwd).toBe(tmpdir)
 	})
 
 	it('getCwd() model getPath() returns invalid path', async () => {
@@ -211,7 +209,7 @@ describe('XTerminalElement', () => {
 			'previousActiveItem',
 			['getPath'],
 		)
-		previousActiveItem.getPath.and.returnValue(path.join(this.tmpdir, 'non-existent-dir'))
+		previousActiveItem.getPath.and.returnValue(path.join(tmpdir, 'non-existent-dir'))
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(
 			previousActiveItem,
 		)
@@ -221,16 +219,16 @@ describe('XTerminalElement', () => {
 	})
 
 	it('getCwd() non-existent cwd set in uri', async () => {
-		const dir = path.join(this.tmpdir, 'non-existent-dir')
+		const dir = path.join(tmpdir, 'non-existent-dir')
 		const params = new URLSearchParams({ cwd: dir })
 		const url = new URL('x-terminal://?' + params.toString())
 		await createNewElement(url.href)
-		const cwd = await this.element.getCwd()
+		const cwd = await element.getCwd()
 		expect(cwd).toBe(configDefaults.cwd)
 	})
 
 	it('getCwd() non-existent project path added', async () => {
-		spyOn(atom.project, 'getPaths').and.returnValue([path.join(this.tmpdir, 'non-existent-dir')])
+		spyOn(atom.project, 'getPaths').and.returnValue([path.join(tmpdir, 'non-existent-dir')])
 		const element = await createNewElement()
 		const cwd = await element.getCwd()
 		expect(cwd).toBe(configDefaults.cwd)
@@ -240,7 +238,7 @@ describe('XTerminalElement', () => {
 		const NODE_ENV = process.env.NODE_ENV
 		try {
 			delete process.env.NODE_ENV
-			expect(JSON.stringify(this.element.getEnv())).toEqual(JSON.stringify(process.env))
+			expect(JSON.stringify(element.getEnv())).toEqual(JSON.stringify(process.env))
 		} finally {
 			process.env.NODE_ENV = NODE_ENV
 		}
@@ -255,8 +253,8 @@ describe('XTerminalElement', () => {
 	})
 
 	it('getEnv() throw exception when env is not an object', () => {
-		this.element.model.profile.env = []
-		expect(() => { this.element.getEnv() }).toThrow(new Error('Environment set is not an object.'))
+		element.model.profile.env = []
+		expect(() => { element.getEnv() }).toThrow(new Error('Environment set is not an object.'))
 	})
 
 	it('getEnv() setEnv set in uri', async () => {
@@ -270,25 +268,25 @@ describe('XTerminalElement', () => {
 	it('getEnv() deleteEnv set in config', () => {
 		atom.config.set('x-terminal.spawnPtySettings.env', JSON.stringify({ var1: 'value1' }))
 		atom.config.set('x-terminal.spawnPtySettings.deleteEnv', JSON.stringify(['var1']))
-		expect(this.element.getEnv().var1).toBe(undefined)
+		expect(element.getEnv().var1).toBe(undefined)
 	})
 
 	it('getEnv() deleteEnv set in uri', async () => {
 		const params = new URLSearchParams({ env: JSON.stringify({ var1: 'value1' }), deleteEnv: JSON.stringify(['var1']) })
 		const url = new URL('x-terminal://?' + params.toString())
 		await createNewElement(url.href)
-		expect(this.element.getEnv().var1).toBe(undefined)
+		expect(element.getEnv().var1).toBe(undefined)
 	})
 
 	it('getEnv() deleteEnv has precendence over senEnv', () => {
 		atom.config.set('x-terminal.spawnPtySettings.env', JSON.stringify({ var1: 'value1' }))
 		atom.config.set('x-terminal.spawnPtySettings.setEnv', JSON.stringify({ var2: 'value2' }))
 		atom.config.set('x-terminal.spawnPtySettings.deleteEnv', JSON.stringify(['var2']))
-		expect(this.element.getEnv().var2).toBe(undefined)
+		expect(element.getEnv().var2).toBe(undefined)
 	})
 
 	it('getEncoding()', () => {
-		expect(this.element.getEncoding()).toBeNull()
+		expect(element.getEncoding()).toBeNull()
 	})
 
 	it('getEncoding() encoding set in uri', async () => {
@@ -300,7 +298,7 @@ describe('XTerminalElement', () => {
 	})
 
 	it('leaveOpenAfterExit()', () => {
-		expect(this.element.leaveOpenAfterExit()).toBe(true)
+		expect(element.leaveOpenAfterExit()).toBe(true)
 	})
 
 	it('leaveOpenAfterExit() true set in uri', async () => {
@@ -320,7 +318,7 @@ describe('XTerminalElement', () => {
 	})
 
 	it('isPromptToStartup()', () => {
-		expect(this.element.isPromptToStartup()).toBe(false)
+		expect(element.isPromptToStartup()).toBe(false)
 	})
 
 	it('isPromptToStartup() false set in uri', async () => {
@@ -340,26 +338,26 @@ describe('XTerminalElement', () => {
 	})
 
 	it('isPtyProcessRunning() ptyProcess null, ptyProcessRunning false', () => {
-		this.element.ptyProcess = null
-		this.element.ptyProcessRunning = false
-		expect(this.element.isPtyProcessRunning()).toBeFalsy()
+		element.ptyProcess = null
+		element.ptyProcessRunning = false
+		expect(element.isPtyProcessRunning()).toBeFalsy()
 	})
 
 	it('isPtyProcessRunning() ptyProcess not null, ptyProcessRunning false', () => {
-		this.element.ptyProcess = jasmine.createSpyObj('ptyProcess', ['kill'])
-		this.element.ptyProcessRunning = false
-		expect(this.element.isPtyProcessRunning()).toBeFalsy()
+		element.ptyProcess = jasmine.createSpyObj('ptyProcess', ['kill'])
+		element.ptyProcessRunning = false
+		expect(element.isPtyProcessRunning()).toBeFalsy()
 	})
 
 	it('isPtyProcessRunning() ptyProcess not null, ptyProcessRunning true', () => {
-		this.element.ptyProcess = jasmine.createSpyObj('ptyProcess', ['kill'])
-		this.element.ptyProcessRunning = true
-		expect(this.element.isPtyProcessRunning()).toBeTruthy()
+		element.ptyProcess = jasmine.createSpyObj('ptyProcess', ['kill'])
+		element.ptyProcessRunning = true
+		expect(element.isPtyProcessRunning()).toBeTruthy()
 	})
 
 	describe('getTheme()', () => {
 		it('Custom', () => {
-			const theme = this.element.getTheme({ theme: 'Custom' })
+			const theme = element.getTheme({ theme: 'Custom' })
 			expect(theme).toEqual({
 				background: '#000000',
 				foreground: '#ffffff',
@@ -396,7 +394,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Atom Dark', () => {
-			const theme = this.element.getTheme({ theme: 'Atom Dark' })
+			const theme = element.getTheme({ theme: 'Atom Dark' })
 			expect(theme).toEqual({
 				background: '#1d1f21',
 				foreground: '#c5c8c6',
@@ -433,7 +431,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Atom Light', () => {
-			const theme = this.element.getTheme({ theme: 'Atom Light' })
+			const theme = element.getTheme({ theme: 'Atom Light' })
 			expect(theme).toEqual({
 				background: '#ffffff',
 				foreground: '#555555',
@@ -470,7 +468,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Base16 Tomorrow Dark', () => {
-			const theme = this.element.getTheme({ theme: 'Base16 Tomorrow Dark' })
+			const theme = element.getTheme({ theme: 'Base16 Tomorrow Dark' })
 			expect(theme).toEqual({
 				background: '#1d1f21',
 				foreground: '#c5c8c6',
@@ -508,7 +506,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Base16 Tomorrow Light', () => {
-			const theme = this.element.getTheme({ theme: 'Base16 Tomorrow Light' })
+			const theme = element.getTheme({ theme: 'Base16 Tomorrow Light' })
 			expect(theme).toEqual({
 				background: '#ffffff',
 				foreground: '#1d1f21',
@@ -546,7 +544,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Christmas', () => {
-			const theme = this.element.getTheme({ theme: 'Christmas' })
+			const theme = element.getTheme({ theme: 'Christmas' })
 			expect(theme).toEqual({
 				background: '#0c0047',
 				foreground: '#f81705',
@@ -583,7 +581,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('City Lights', () => {
-			const theme = this.element.getTheme({ theme: 'City Lights' })
+			const theme = element.getTheme({ theme: 'City Lights' })
 			expect(theme).toEqual({
 				background: '#181d23',
 				foreground: '#666d81',
@@ -621,7 +619,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Dracula', () => {
-			const theme = this.element.getTheme({ theme: 'Dracula' })
+			const theme = element.getTheme({ theme: 'Dracula' })
 			expect(theme).toEqual({
 				background: '#1e1f29',
 				foreground: 'white',
@@ -658,7 +656,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Grass', () => {
-			const theme = this.element.getTheme({ theme: 'Grass' })
+			const theme = element.getTheme({ theme: 'Grass' })
 			expect(theme).toEqual({
 				background: 'rgb(19, 119, 61)',
 				foreground: 'rgb(255, 240, 165)',
@@ -695,7 +693,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Homebrew', () => {
-			const theme = this.element.getTheme({ theme: 'Homebrew' })
+			const theme = element.getTheme({ theme: 'Homebrew' })
 			expect(theme).toEqual({
 				background: '#000000',
 				foreground: 'rgb(41, 254, 20)',
@@ -732,7 +730,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Inverse', () => {
-			const theme = this.element.getTheme({ theme: 'Inverse' })
+			const theme = element.getTheme({ theme: 'Inverse' })
 			expect(theme).toEqual({
 				background: '#ffffff',
 				foreground: '#000000',
@@ -769,7 +767,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Linux', () => {
-			const theme = this.element.getTheme({ theme: 'Linux' })
+			const theme = element.getTheme({ theme: 'Linux' })
 			expect(theme).toEqual({
 				background: '#000000',
 				foreground: 'rgb(230, 230, 230)',
@@ -806,7 +804,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Man Page', () => {
-			const theme = this.element.getTheme({ theme: 'Man Page' })
+			const theme = element.getTheme({ theme: 'Man Page' })
 			expect(theme).toEqual({
 				background: 'rgb(254, 244, 156)',
 				foreground: 'black',
@@ -843,7 +841,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Novel', () => {
-			const theme = this.element.getTheme({ theme: 'Novel' })
+			const theme = element.getTheme({ theme: 'Novel' })
 			expect(theme).toEqual({
 				background: 'rgb(223, 219, 196)',
 				foreground: 'rgb(77, 47, 46)',
@@ -880,7 +878,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Ocean', () => {
-			const theme = this.element.getTheme({ theme: 'Ocean' })
+			const theme = element.getTheme({ theme: 'Ocean' })
 			expect(theme).toEqual({
 				background: 'rgb(44, 102, 201)',
 				foreground: 'white',
@@ -917,7 +915,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('One Dark', () => {
-			const theme = this.element.getTheme({ theme: 'One Dark' })
+			const theme = element.getTheme({ theme: 'One Dark' })
 			expect(theme).toEqual({
 				background: '#282c34',
 				foreground: '#abb2bf',
@@ -954,7 +952,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('One Light', () => {
-			const theme = this.element.getTheme({ theme: 'One Light' })
+			const theme = element.getTheme({ theme: 'One Light' })
 			expect(theme).toEqual({
 				background: 'hsl(230, 1%, 98%)',
 				foreground: 'hsl(230, 8%, 24%)',
@@ -991,7 +989,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Predawn', () => {
-			const theme = this.element.getTheme({ theme: 'Predawn' })
+			const theme = element.getTheme({ theme: 'Predawn' })
 			expect(theme).toEqual({
 				background: '#282828',
 				foreground: '#f1f1f1',
@@ -1028,7 +1026,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Pro', () => {
-			const theme = this.element.getTheme({ theme: 'Pro' })
+			const theme = element.getTheme({ theme: 'Pro' })
 			expect(theme).toEqual({
 				background: '#000000',
 				foreground: 'rgb(244, 244, 244)',
@@ -1065,7 +1063,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Red Sands', () => {
-			const theme = this.element.getTheme({ theme: 'Red Sands' })
+			const theme = element.getTheme({ theme: 'Red Sands' })
 			expect(theme).toEqual({
 				background: 'rgb(143, 53, 39)',
 				foreground: 'rgb(215, 201, 167)',
@@ -1102,7 +1100,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Red', () => {
-			const theme = this.element.getTheme({ theme: 'Red' })
+			const theme = element.getTheme({ theme: 'Red' })
 			expect(theme).toEqual({
 				background: '#000000',
 				foreground: 'rgb(255, 38, 14)',
@@ -1139,7 +1137,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Silver Aerogel', () => {
-			const theme = this.element.getTheme({ theme: 'Silver Aerogel' })
+			const theme = element.getTheme({ theme: 'Silver Aerogel' })
 			expect(theme).toEqual({
 				background: 'rgb(146, 146, 146)',
 				foreground: '#000000',
@@ -1176,7 +1174,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Solarized Dark', () => {
-			const theme = this.element.getTheme({ theme: 'Solarized Dark' })
+			const theme = element.getTheme({ theme: 'Solarized Dark' })
 			expect(theme).toEqual({
 				background: '#042029',
 				foreground: '#708284',
@@ -1213,7 +1211,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Solarized Light', () => {
-			const theme = this.element.getTheme({ theme: 'Solarized Light' })
+			const theme = element.getTheme({ theme: 'Solarized Light' })
 			expect(theme).toEqual({
 				background: '#fdf6e3',
 				foreground: '#657a81',
@@ -1250,7 +1248,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Solid Colors', () => {
-			const theme = this.element.getTheme({ theme: 'Solid Colors' })
+			const theme = element.getTheme({ theme: 'Solid Colors' })
 			expect(theme).toEqual({
 				background: 'rgb(120, 132, 151)',
 				foreground: '#000000',
@@ -1287,7 +1285,7 @@ describe('XTerminalElement', () => {
 		}
 
 		it('Standard', () => {
-			const theme = this.element.getTheme({ theme: 'Standard' })
+			const theme = element.getTheme({ theme: 'Standard' })
 			const root = getComputedStyle(document.documentElement)
 			expect(theme).toEqual({
 				background: root.getPropertyValue('--standard-app-background-color'),
@@ -1327,11 +1325,11 @@ describe('XTerminalElement', () => {
 	})
 
 	it('createTerminal() check terminal object', () => {
-		expect(this.element.terminal).toBeTruthy()
+		expect(element.terminal).toBeTruthy()
 	})
 
 	it('createTerminal() check ptyProcess object', () => {
-		expect(this.element.ptyProcess).toBeTruthy()
+		expect(element.ptyProcess).toBeTruthy()
 	})
 
 	describe('loaded addons', () => {
@@ -1387,15 +1385,15 @@ describe('XTerminalElement', () => {
 	})
 
 	it('restartPtyProcess() check new pty process created', async () => {
-		const oldPtyProcess = this.element.ptyProcess
+		const oldPtyProcess = element.ptyProcess
 		const newPtyProcess = jasmine.createSpyObj('ptyProcess',
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = jasmine.createSpy('process')
 			.and.returnValue('sometestprocess')
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		await this.element.restartPtyProcess()
-		expect(this.element.ptyProcess).toBe(newPtyProcess)
-		expect(oldPtyProcess).not.toBe(this.element.ptyProcess)
+		await element.restartPtyProcess()
+		expect(element.ptyProcess).toBe(newPtyProcess)
+		expect(oldPtyProcess).not.toBe(element.ptyProcess)
 	})
 
 	it('restartPtyProcess() check ptyProcessRunning set to true', async () => {
@@ -1404,21 +1402,21 @@ describe('XTerminalElement', () => {
 		newPtyProcess.process = jasmine.createSpy('process')
 			.and.returnValue('sometestprocess')
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		await this.element.restartPtyProcess()
-		expect(this.element.ptyProcessRunning).toBe(true)
+		await element.restartPtyProcess()
+		expect(element.ptyProcessRunning).toBe(true)
 	})
 
 	it('restartPtyProcess() command not found', async () => {
-		spyOn(this.element, 'showNotification')
-		this.element.model.profile.command = 'somecommand'
+		spyOn(element, 'showNotification')
+		element.model.profile.command = 'somecommand'
 		const fakeCall = () => {
 			throw Error('File not found: somecommand')
 		}
 		nodePty.spawn.and.callFake(fakeCall)
-		await this.element.restartPtyProcess()
-		expect(this.element.ptyProcess).toBe(null)
-		expect(this.element.ptyProcessRunning).toBe(false)
-		expect(this.element.showNotification.calls.argsFor(0)).toEqual(
+		await element.restartPtyProcess()
+		expect(element.ptyProcess).toBe(null)
+		expect(element.ptyProcessRunning).toBe(false)
+		expect(element.showNotification.calls.argsFor(0)).toEqual(
 			[
 				"Could not find command 'somecommand'.",
 				'error',
@@ -1427,16 +1425,16 @@ describe('XTerminalElement', () => {
 	})
 
 	it('restartPtyProcess() some other error thrown', async () => {
-		spyOn(this.element, 'showNotification')
-		this.element.model.profile.command = 'somecommand'
+		spyOn(element, 'showNotification')
+		element.model.profile.command = 'somecommand'
 		const fakeCall = () => {
 			throw Error('Something went wrong')
 		}
 		nodePty.spawn.and.callFake(fakeCall)
-		await this.element.restartPtyProcess()
-		expect(this.element.ptyProcess).toBe(null)
-		expect(this.element.ptyProcessRunning).toBe(false)
-		expect(this.element.showNotification.calls.argsFor(0)).toEqual(
+		await element.restartPtyProcess()
+		expect(element.ptyProcess).toBe(null)
+		expect(element.ptyProcessRunning).toBe(false)
+		expect(element.showNotification.calls.argsFor(0)).toEqual(
 			[
 				"Launching 'somecommand' raised the following error: Something went wrong",
 				'error',
@@ -1446,476 +1444,476 @@ describe('XTerminalElement', () => {
 
 	it('ptyProcess exit handler set ptyProcessRunning to false', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(false)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(false)
 		exitHandler(0)
-		expect(this.element.ptyProcessRunning).toBe(false)
+		expect(element.ptyProcessRunning).toBe(false)
 	})
 
 	it('ptyProcess exit handler code 0 don\'t leave open', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(false)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(false)
 		exitHandler(0)
-		expect(this.element.model.exit).toHaveBeenCalled()
+		expect(element.model.exit).toHaveBeenCalled()
 	})
 
 	it('ptyProcess exit handler code 1 don\'t leave open', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(false)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(false)
 		exitHandler(1)
-		expect(this.element.model.exit).toHaveBeenCalled()
+		expect(element.model.exit).toHaveBeenCalled()
 	})
 
 	it('ptyProcess exit handler code 0 leave open', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(true)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(true)
 		exitHandler(0)
-		expect(this.element.model.exit).not.toHaveBeenCalled()
+		expect(element.model.exit).not.toHaveBeenCalled()
 	})
 
 	it('ptyProcess exit handler code 0 leave open check top message', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(true)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(true)
 		exitHandler(0)
-		const successDiv = this.element.topDiv.querySelector('.x-terminal-notice-success')
-		const errorDiv = this.element.topDiv.querySelector('.x-terminal-notice-error')
+		const successDiv = element.topDiv.querySelector('.x-terminal-notice-success')
+		const errorDiv = element.topDiv.querySelector('.x-terminal-notice-error')
 		expect(successDiv).not.toBeNull()
 		expect(errorDiv).toBeNull()
 	})
 
 	it('ptyProcess exit handler code 1 leave open check top message', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(true)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(true)
 		exitHandler(1)
-		const successDiv = this.element.topDiv.querySelector('.x-terminal-notice-success')
-		const errorDiv = this.element.topDiv.querySelector('.x-terminal-notice-error')
+		const successDiv = element.topDiv.querySelector('.x-terminal-notice-success')
+		const errorDiv = element.topDiv.querySelector('.x-terminal-notice-error')
 		expect(successDiv).toBeNull()
 		expect(errorDiv).not.toBeNull()
 	})
 
 	it('ptyProcess exit handler code 0 leave open check top message has restart button', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(true)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(true)
 		exitHandler(0)
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-success')
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-success')
 		const restartButton = messageDiv.querySelector('.btn-success')
 		expect(restartButton).not.toBeNull()
 	})
 
 	it('ptyProcess exit handler code 1 leave open check top message has restart button', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(true)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(true)
 		exitHandler(1)
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-error')
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-error')
 		const restartButton = messageDiv.querySelector('.btn-error')
 		expect(restartButton).not.toBeNull()
 	})
 
 	it('ptyProcess exit handler code 0 leave open check restart button click handler', () => {
 		let exitHandler
-		for (const arg of this.element.ptyProcess.on.calls.allArgs()) {
+		for (const arg of element.ptyProcess.on.calls.allArgs()) {
 			if (arg[0] === 'exit') {
 				exitHandler = arg[1]
 				break
 			}
 		}
-		spyOn(this.element.model, 'exit')
-		spyOn(this.element, 'leaveOpenAfterExit').and.returnValue(true)
+		spyOn(element.model, 'exit')
+		spyOn(element, 'leaveOpenAfterExit').and.returnValue(true)
 		exitHandler(0)
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-success')
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-success')
 		const restartButton = messageDiv.querySelector('.btn-success')
-		spyOn(this.element, 'restartPtyProcess')
+		spyOn(element, 'restartPtyProcess')
 		const mouseEvent = new MouseEvent('click')
 		restartButton.dispatchEvent(mouseEvent)
-		expect(this.element.restartPtyProcess).toHaveBeenCalled()
+		expect(element.restartPtyProcess).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() initial state', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions')
-		this.element.refitTerminal()
-		expect(this.element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
+		spyOn(element.fitAddon, 'proposeDimensions')
+		element.refitTerminal()
+		expect(element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal not visible', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = false
-		this.element.refitTerminal()
-		expect(this.element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
+		spyOn(element.fitAddon, 'proposeDimensions')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = false
+		element.refitTerminal()
+		expect(element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal no width', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions')
-		this.element.mainDivContentRect = { width: 0, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.refitTerminal()
-		expect(this.element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
+		spyOn(element.fitAddon, 'proposeDimensions')
+		element.mainDivContentRect = { width: 0, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.refitTerminal()
+		expect(element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal no height', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions')
-		this.element.mainDivContentRect = { width: 1, height: 0 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.refitTerminal()
-		expect(this.element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
+		spyOn(element.fitAddon, 'proposeDimensions')
+		element.mainDivContentRect = { width: 1, height: 0 }
+		element.terminalDivInitiallyVisible = true
+		element.refitTerminal()
+		expect(element.fitAddon.proposeDimensions).not.toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal completely visible', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(null)
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.refitTerminal()
-		expect(this.element.fitAddon.proposeDimensions).toHaveBeenCalled()
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(null)
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.refitTerminal()
+		expect(element.fitAddon.proposeDimensions).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal size not changed', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.terminal.cols,
-			rows: this.element.terminal.rows,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.terminal.cols,
+			rows: element.terminal.rows,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = false
-		this.element.refitTerminal()
-		expect(this.element.terminal.resize).not.toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = false
+		element.refitTerminal()
+		expect(element.terminal.resize).not.toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal size cols increased', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.terminal.cols + 1,
-			rows: this.element.terminal.rows,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.terminal.cols + 1,
+			rows: element.terminal.rows,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = false
-		this.element.refitTerminal()
-		expect(this.element.terminal.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = false
+		element.refitTerminal()
+		expect(element.terminal.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal size rows increased', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.terminal.cols,
-			rows: this.element.terminal.rows + 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.terminal.cols,
+			rows: element.terminal.rows + 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = false
-		this.element.refitTerminal()
-		expect(this.element.terminal.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = false
+		element.refitTerminal()
+		expect(element.terminal.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal size cols and rows increased', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.terminal.cols + 1,
-			rows: this.element.terminal.rows + 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.terminal.cols + 1,
+			rows: element.terminal.rows + 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = false
-		this.element.refitTerminal()
-		expect(this.element.terminal.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = false
+		element.refitTerminal()
+		expect(element.terminal.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal size rows decreased', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.terminal.cols,
-			rows: this.element.terminal.rows - 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.terminal.cols,
+			rows: element.terminal.rows - 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = false
-		this.element.refitTerminal()
-		expect(this.element.terminal.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = false
+		element.refitTerminal()
+		expect(element.terminal.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() terminal size cols and rows decreased', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.terminal.cols - 1,
-			rows: this.element.terminal.rows - 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.terminal.cols - 1,
+			rows: element.terminal.rows - 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = false
-		this.element.refitTerminal()
-		expect(this.element.terminal.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = false
+		element.refitTerminal()
+		expect(element.terminal.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size not changed ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols,
-			rows: this.element.ptyProcessRows,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols,
+			rows: element.ptyProcessRows,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).not.toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).not.toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size cols increased ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols + 1,
-			rows: this.element.ptyProcessRows,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols + 1,
+			rows: element.ptyProcessRows,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size rows increased ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols,
-			rows: this.element.ptyProcessRows + 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols,
+			rows: element.ptyProcessRows + 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size cols and rows increased ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols + 1,
-			rows: this.element.ptyProcessRows + 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols + 1,
+			rows: element.ptyProcessRows + 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size cols decreased ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols - 1,
-			rows: this.element.ptyProcessRows,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols - 1,
+			rows: element.ptyProcessRows,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size rows decreased ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols,
-			rows: this.element.ptyProcessRows - 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols,
+			rows: element.ptyProcessRows - 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size cols and rows decreased ptyProcess running', () => {
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue({
-			cols: this.element.ptyProcessCols - 1,
-			rows: this.element.ptyProcessRows - 1,
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue({
+			cols: element.ptyProcessCols - 1,
+			rows: element.ptyProcessRows - 1,
 		})
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalled()
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalled()
 	})
 
 	it('refitTerminal() pty process size cols increased ptyProcess running check call args', () => {
 		const expected = {
-			cols: this.element.ptyProcessCols + 1,
-			rows: this.element.ptyProcessRows,
+			cols: element.ptyProcessCols + 1,
+			rows: element.ptyProcessRows,
 		}
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(expected)
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(expected)
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
 	})
 
 	it('refitTerminal() pty process size rows increased ptyProcess running check call args', () => {
 		const expected = {
-			cols: this.element.ptyProcessCols,
-			rows: this.element.ptyProcessRows + 1,
+			cols: element.ptyProcessCols,
+			rows: element.ptyProcessRows + 1,
 		}
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(expected)
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(expected)
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
 	})
 
 	it('refitTerminal() pty process size cols and rows increased ptyProcess running check call args', () => {
 		const expected = {
-			cols: this.element.ptyProcessCols + 1,
-			rows: this.element.ptyProcessRows + 1,
+			cols: element.ptyProcessCols + 1,
+			rows: element.ptyProcessRows + 1,
 		}
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(expected)
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(expected)
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
 	})
 
 	it('refitTerminal() pty process size cols decreased ptyProcess running check call args', () => {
 		const expected = {
-			cols: this.element.ptyProcessCols - 1,
-			rows: this.element.ptyProcessRows,
+			cols: element.ptyProcessCols - 1,
+			rows: element.ptyProcessRows,
 		}
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(expected)
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(expected)
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
 	})
 
 	it('refitTerminal() pty process size rows decreased ptyProcess running check call args', () => {
 		const expected = {
-			cols: this.element.ptyProcessCols,
-			rows: this.element.ptyProcessRows - 1,
+			cols: element.ptyProcessCols,
+			rows: element.ptyProcessRows - 1,
 		}
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(expected)
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(expected)
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
 	})
 
 	it('refitTerminal() pty process size cols and rows decreased ptyProcess running check call args', () => {
 		const expected = {
-			cols: this.element.ptyProcessCols - 1,
-			rows: this.element.ptyProcessRows - 1,
+			cols: element.ptyProcessCols - 1,
+			rows: element.ptyProcessRows - 1,
 		}
-		spyOn(this.element.fitAddon, 'proposeDimensions').and.returnValue(expected)
-		spyOn(this.element.terminal, 'resize')
-		this.element.mainDivContentRect = { width: 1, height: 1 }
-		this.element.terminalDivInitiallyVisible = true
-		this.element.ptyProcessRunning = true
-		this.element.refitTerminal()
-		expect(this.element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
+		spyOn(element.fitAddon, 'proposeDimensions').and.returnValue(expected)
+		spyOn(element.terminal, 'resize')
+		element.mainDivContentRect = { width: 1, height: 1 }
+		element.terminalDivInitiallyVisible = true
+		element.ptyProcessRunning = true
+		element.refitTerminal()
+		expect(element.ptyProcess.resize).toHaveBeenCalledWith(expected.cols, expected.rows)
 	})
 
 	it('focusOnTerminal()', () => {
-		spyOn(this.element.terminal, 'focus')
-		spyOn(this.element.model, 'setActive')
-		this.element.focusOnTerminal()
-		expect(this.element.model.setActive).toHaveBeenCalled()
-		expect(this.element.terminal.focus).toHaveBeenCalled()
+		spyOn(element.terminal, 'focus')
+		spyOn(element.model, 'setActive')
+		element.focusOnTerminal()
+		expect(element.model.setActive).toHaveBeenCalled()
+		expect(element.terminal.focus).toHaveBeenCalled()
 	})
 
 	it('focusOnTerminal() terminal not set', () => {
-		this.element.terminal = null
-		this.element.focusOnTerminal()
+		element.terminal = null
+		element.focusOnTerminal()
 	})
 
 	it('toggleProfileMenu()', (done) => {
-		this.element.atomXtermProfileMenuElement = jasmine.createSpyObj(
+		element.atomXtermProfileMenuElement = jasmine.createSpyObj(
 			'atomXtermProfileMenuElement',
 			[
 				'toggleProfileMenu',
 				'destroy',
 			],
 		)
-		this.element.atomXtermProfileMenuElement.initializedPromise = Promise.resolve()
-		this.element.atomXtermProfileMenuElement.toggleProfileMenu.and.callFake(() => {
+		element.atomXtermProfileMenuElement.initializedPromise = Promise.resolve()
+		element.atomXtermProfileMenuElement.toggleProfileMenu.and.callFake(() => {
 			done()
 		})
-		this.element.toggleProfileMenu()
+		element.toggleProfileMenu()
 	})
 
 	it('hideTerminal()', () => {
-		this.element.hideTerminal()
-		expect(this.element.terminalDiv.style.visibility).toBe('hidden')
+		element.hideTerminal()
+		expect(element.terminalDiv.style.visibility).toBe('hidden')
 	})
 
 	it('showTerminal()', () => {
-		this.element.showTerminal()
-		expect(this.element.terminalDiv.style.visibility).toBe('visible')
+		element.showTerminal()
+		expect(element.terminalDiv.style.visibility).toBe('visible')
 	})
 
 	it('hoveredLink initially null', () => {
-		expect(this.element.hoveredLink).toBeNull()
+		expect(element.hoveredLink).toBeNull()
 	})
 
 	it('on \'data\' handler no custom title on win32 platform', async () => {
@@ -1926,11 +1924,11 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(0)
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(0)
 		const onDataCallback = args[1]
 		onDataCallback('')
-		expect(this.element.model.title).toBe('X Terminal')
+		expect(element.model.title).toBe('X Terminal')
 	})
 
 	it('on \'data\' handler no custom title on linux platform', async () => {
@@ -1941,11 +1939,11 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(0)
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(0)
 		const onDataCallback = args[1]
 		onDataCallback('')
-		expect(this.element.model.title).toBe('sometestprocess')
+		expect(element.model.title).toBe('sometestprocess')
 	})
 
 	it('on \'data\' handler custom title on win32 platform', async () => {
@@ -1956,12 +1954,12 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		this.element.model.profile.title = 'foo'
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(0)
+		element.model.profile.title = 'foo'
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(0)
 		const onDataCallback = args[1]
 		onDataCallback('')
-		expect(this.element.model.title).toBe('foo')
+		expect(element.model.title).toBe('foo')
 	})
 
 	it('on \'data\' handler custom title on linux platform', async () => {
@@ -1972,12 +1970,12 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		this.element.model.profile.title = 'foo'
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(0)
+		element.model.profile.title = 'foo'
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(0)
 		const onDataCallback = args[1]
 		onDataCallback('')
-		expect(this.element.model.title).toBe('foo')
+		expect(element.model.title).toBe('foo')
 	})
 
 	it('on \'exit\' handler leave open after exit success', async () => {
@@ -1985,14 +1983,14 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		this.element.model.profile.title = 'foo'
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(1)
+		element.model.profile.title = 'foo'
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(1)
 		const onExitCallback = args[1]
-		this.element.model.profile.leaveOpenAfterExit = true
+		element.model.profile.leaveOpenAfterExit = true
 		onExitCallback(0)
-		expect(this.element.querySelector('.x-terminal-notice-success')).toBeTruthy()
-		expect(this.element.querySelector('.x-terminal-notice-error')).toBe(null)
+		expect(element.querySelector('.x-terminal-notice-success')).toBeTruthy()
+		expect(element.querySelector('.x-terminal-notice-error')).toBe(null)
 	})
 
 	it('on \'exit\' handler leave open after exit failure', async () => {
@@ -2000,14 +1998,14 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		this.element.model.profile.title = 'foo'
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(1)
+		element.model.profile.title = 'foo'
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(1)
 		const onExitCallback = args[1]
-		this.element.model.profile.leaveOpenAfterExit = true
+		element.model.profile.leaveOpenAfterExit = true
 		onExitCallback(1)
-		expect(this.element.querySelector('.x-terminal-notice-success')).toBe(null)
-		expect(this.element.querySelector('.x-terminal-notice-error')).toBeTruthy()
+		expect(element.querySelector('.x-terminal-notice-success')).toBe(null)
+		expect(element.querySelector('.x-terminal-notice-error')).toBeTruthy()
 	})
 
 	it('on \'exit\' handler do not leave open', async () => {
@@ -2015,37 +2013,37 @@ describe('XTerminalElement', () => {
 			['kill', 'write', 'resize', 'on', 'removeAllListeners'])
 		newPtyProcess.process = 'sometestprocess'
 		nodePty.spawn.and.returnValue(newPtyProcess)
-		this.element.model.profile.title = 'foo'
-		await this.element.restartPtyProcess()
-		const args = this.element.ptyProcess.on.calls.argsFor(1)
+		element.model.profile.title = 'foo'
+		await element.restartPtyProcess()
+		const args = element.ptyProcess.on.calls.argsFor(1)
 		const onExitCallback = args[1]
-		this.element.model.profile.leaveOpenAfterExit = false
-		spyOn(this.element.model, 'exit')
+		element.model.profile.leaveOpenAfterExit = false
+		spyOn(element.model, 'exit')
 		onExitCallback(1)
-		expect(this.element.model.exit).toHaveBeenCalled()
+		expect(element.model.exit).toHaveBeenCalled()
 	})
 
 	it('showNotification() success message', () => {
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'success',
 		)
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-success')
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-success')
 		expect(messageDiv.textContent).toBe('fooRestart')
 	})
 
 	it('showNotification() error message', () => {
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'error',
 		)
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-error')
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-error')
 		expect(messageDiv.textContent).toBe('fooRestart')
 	})
 
 	it('showNotification() success message with Atom notification', () => {
 		spyOn(atom.notifications, 'addSuccess')
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'success',
 		)
@@ -2054,7 +2052,7 @@ describe('XTerminalElement', () => {
 
 	it('showNotification() error message with Atom notification', () => {
 		spyOn(atom.notifications, 'addError')
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'error',
 		)
@@ -2063,7 +2061,7 @@ describe('XTerminalElement', () => {
 
 	it('showNotification() warning message with Atom notification', () => {
 		spyOn(atom.notifications, 'addWarning')
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'warning',
 		)
@@ -2072,7 +2070,7 @@ describe('XTerminalElement', () => {
 
 	it('showNotification() info message with Atom notification', () => {
 		spyOn(atom.notifications, 'addInfo')
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'info',
 		)
@@ -2081,7 +2079,7 @@ describe('XTerminalElement', () => {
 
 	it('showNotification() bogus info type with Atom notification', () => {
 		const call = () => {
-			this.element.showNotification(
+			element.showNotification(
 				'foo',
 				'bogus',
 			)
@@ -2090,36 +2088,36 @@ describe('XTerminalElement', () => {
 	})
 
 	it('showNotification() custom restart button text', () => {
-		this.element.showNotification(
+		element.showNotification(
 			'foo',
 			'info',
 			'Some text',
 		)
-		const restartButton = this.element.topDiv.querySelector('.x-terminal-restart-btn')
+		const restartButton = element.topDiv.querySelector('.x-terminal-restart-btn')
 		expect(restartButton.firstChild.nodeValue).toBe('Some text')
 	})
 
 	it('promptToStartup()', async () => {
-		await this.element.promptToStartup()
-		const restartButton = this.element.topDiv.querySelector('.x-terminal-restart-btn')
+		await element.promptToStartup()
+		const restartButton = element.topDiv.querySelector('.x-terminal-restart-btn')
 		expect(restartButton.firstChild.nodeValue).toBe('Start')
 	})
 
 	it('promptToStartup() check message without title', async () => {
 		const command = ['some_command', 'a', 'b', 'c']
-		spyOn(this.element, 'getShellCommand').and.returnValue(command[0])
-		spyOn(this.element, 'getArgs').and.returnValue(command.slice(1))
+		spyOn(element, 'getShellCommand').and.returnValue(command[0])
+		spyOn(element, 'getArgs').and.returnValue(command.slice(1))
 		const expected = `New command ${JSON.stringify(command)} ready to start.`
-		await this.element.promptToStartup()
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-info')
+		await element.promptToStartup()
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-info')
 		expect(messageDiv.firstChild.nodeValue).toBe(expected)
 	})
 
 	it('promptToStartup() check message with title', async () => {
-		this.element.model.profile.title = 'My Profile'
+		element.model.profile.title = 'My Profile'
 		const expected = 'New command for profile My Profile ready to start.'
-		await this.element.promptToStartup()
-		const messageDiv = this.element.topDiv.querySelector('.x-terminal-notice-info')
+		await element.promptToStartup()
+		const messageDiv = element.topDiv.querySelector('.x-terminal-notice-info')
 		expect(messageDiv.firstChild.nodeValue).toBe(expected)
 	})
 
@@ -2127,16 +2125,16 @@ describe('XTerminalElement', () => {
 		const wheelEvent = new WheelEvent('wheel', {
 			deltaY: -150,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(14)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(14)
 	})
 
 	it('use wheelScrollDown on terminal container', () => {
 		const wheelEvent = new WheelEvent('wheel', {
 			deltaY: 150,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(14)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(14)
 	})
 
 	it('use ctrl+wheelScrollUp on terminal container, editor.zoomFontWhenCtrlScrolling = true', () => {
@@ -2145,8 +2143,8 @@ describe('XTerminalElement', () => {
 			deltaY: -150,
 			ctrlKey: true,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(15)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(15)
 	})
 
 	it('use ctrl+wheelScrollDown on terminal container, editor.zoomFontWhenCtrlScrolling = true', () => {
@@ -2155,8 +2153,8 @@ describe('XTerminalElement', () => {
 			deltaY: 150,
 			ctrlKey: true,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(13)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(13)
 	})
 
 	it('use ctrl+wheelScrollUp on terminal container, editor.zoomFontWhenCtrlScrolling = false', () => {
@@ -2165,8 +2163,8 @@ describe('XTerminalElement', () => {
 			deltaY: -150,
 			ctrlKey: true,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(14)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(14)
 	})
 
 	it('use ctrl+wheelScrollDown on terminal container, editor.zoomFontWhenCtrlScrolling = false', () => {
@@ -2175,54 +2173,54 @@ describe('XTerminalElement', () => {
 			deltaY: 150,
 			ctrlKey: true,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(14)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(14)
 	})
 
 	it('use ctrl+wheelScrollUp font already at maximum', () => {
-		this.element.model.profile.fontSize = configDefaults.maximumFontSize
+		element.model.profile.fontSize = configDefaults.maximumFontSize
 		const wheelEvent = new WheelEvent('wheel', {
 			deltaY: -150,
 			ctrlKey: true,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(configDefaults.maximumFontSize)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(configDefaults.maximumFontSize)
 	})
 
 	it('use ctrl+wheelScrollDown font already at minimum', () => {
-		this.element.model.profile.fontSize = configDefaults.minimumFontSize
+		element.model.profile.fontSize = configDefaults.minimumFontSize
 		const wheelEvent = new WheelEvent('wheel', {
 			deltaY: 150,
 			ctrlKey: true,
 		})
-		this.element.terminalDiv.dispatchEvent(wheelEvent)
-		expect(this.element.model.profile.fontSize).toBe(configDefaults.minimumFontSize)
+		element.terminalDiv.dispatchEvent(wheelEvent)
+		expect(element.model.profile.fontSize).toBe(configDefaults.minimumFontSize)
 	})
 
 	it('copy on select', async () => {
 		spyOn(atom.clipboard, 'write')
-		this.element.model.profile.copyOnSelect = true
-		await new Promise(resolve => this.element.terminal.write('test', resolve))
-		this.element.terminal.selectLines(0, 0)
-		const selection = this.element.terminal.getSelection()
+		element.model.profile.copyOnSelect = true
+		await new Promise(resolve => element.terminal.write('test', resolve))
+		element.terminal.selectLines(0, 0)
+		const selection = element.terminal.getSelection()
 		expect(atom.clipboard.write).toHaveBeenCalledWith(selection)
 	})
 
 	it('does not copy on clear selection', async () => {
 		spyOn(atom.clipboard, 'write')
-		this.element.model.profile.copyOnSelect = true
-		await new Promise(resolve => this.element.terminal.write('test', resolve))
-		this.element.terminal.selectLines(0, 0)
+		element.model.profile.copyOnSelect = true
+		await new Promise(resolve => element.terminal.write('test', resolve))
+		element.terminal.selectLines(0, 0)
 		atom.clipboard.write.calls.reset()
-		this.element.terminal.clearSelection()
+		element.terminal.clearSelection()
 		expect(atom.clipboard.write).not.toHaveBeenCalled()
 	})
 
 	it('does not copy if copyOnSelect is false', async () => {
 		spyOn(atom.clipboard, 'write')
-		this.element.model.profile.copyOnSelect = false
-		await new Promise(resolve => this.element.terminal.write('test', resolve))
-		this.element.terminal.selectLines(0, 0)
+		element.model.profile.copyOnSelect = false
+		await new Promise(resolve => element.terminal.write('test', resolve))
+		element.terminal.selectLines(0, 0)
 		expect(atom.clipboard.write).not.toHaveBeenCalled()
 	})
 
@@ -2231,100 +2229,100 @@ describe('XTerminalElement', () => {
 			cursorBlink: true,
 			fontSize: 14,
 			fontFamily: 'Menlo, Consolas, DejaVu Sans Mono, monospace',
-			theme: this.element.getTheme(),
+			theme: element.getTheme(),
 		}
-		expect(this.element.getXtermOptions()).toEqual(expected)
+		expect(element.getXtermOptions()).toEqual(expected)
 	})
 
 	it('getXtermOptions() xtermOptions in profile', () => {
-		this.element.model.profile.xtermOptions = {
+		element.model.profile.xtermOptions = {
 			cursorBlink: true,
 		}
 		const expected = {
 			cursorBlink: true,
 			fontSize: 14,
 			fontFamily: 'Menlo, Consolas, DejaVu Sans Mono, monospace',
-			theme: this.element.getTheme(),
+			theme: element.getTheme(),
 		}
-		expect(this.element.getXtermOptions()).toEqual(expected)
+		expect(element.getXtermOptions()).toEqual(expected)
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal not visible', () => {
-		spyOn(this.element, 'refitTerminal')
-		this.element.terminalDivInitiallyVisible = false
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.refitTerminal).not.toHaveBeenCalled()
+		spyOn(element, 'refitTerminal')
+		element.terminalDivInitiallyVisible = false
+		element.applyPendingTerminalProfileOptions()
+		expect(element.refitTerminal).not.toHaveBeenCalled()
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal visible no pending changes', () => {
-		spyOn(this.element, 'refitTerminal')
-		spyOn(this.element, 'setMainBackgroundColor')
-		spyOn(this.element, 'restartPtyProcess')
-		spyOn(this.element.terminal, 'setOption')
-		this.element.terminalDivInitiallyVisible = true
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.setMainBackgroundColor).toHaveBeenCalled()
-		expect(this.element.terminal.setOption).not.toHaveBeenCalled()
-		expect(this.element.restartPtyProcess).not.toHaveBeenCalled()
-		expect(this.element.refitTerminal).toHaveBeenCalled()
+		spyOn(element, 'refitTerminal')
+		spyOn(element, 'setMainBackgroundColor')
+		spyOn(element, 'restartPtyProcess')
+		spyOn(element.terminal, 'setOption')
+		element.terminalDivInitiallyVisible = true
+		element.applyPendingTerminalProfileOptions()
+		expect(element.setMainBackgroundColor).toHaveBeenCalled()
+		expect(element.terminal.setOption).not.toHaveBeenCalled()
+		expect(element.restartPtyProcess).not.toHaveBeenCalled()
+		expect(element.refitTerminal).toHaveBeenCalled()
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal visible pending xtermOptions', () => {
-		spyOn(this.element, 'refitTerminal')
-		spyOn(this.element, 'setMainBackgroundColor')
-		spyOn(this.element, 'restartPtyProcess')
-		spyOn(this.element.terminal, 'setOption')
-		this.element.terminalDivInitiallyVisible = true
-		this.element.pendingTerminalProfileOptions.xtermOptions = {
+		spyOn(element, 'refitTerminal')
+		spyOn(element, 'setMainBackgroundColor')
+		spyOn(element, 'restartPtyProcess')
+		spyOn(element.terminal, 'setOption')
+		element.terminalDivInitiallyVisible = true
+		element.pendingTerminalProfileOptions.xtermOptions = {
 			cursorBlink: true,
 		}
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.setMainBackgroundColor).toHaveBeenCalled()
-		expect(this.element.terminal.setOption).toHaveBeenCalled()
-		expect(this.element.restartPtyProcess).not.toHaveBeenCalled()
-		expect(this.element.refitTerminal).toHaveBeenCalled()
+		element.applyPendingTerminalProfileOptions()
+		expect(element.setMainBackgroundColor).toHaveBeenCalled()
+		expect(element.terminal.setOption).toHaveBeenCalled()
+		expect(element.restartPtyProcess).not.toHaveBeenCalled()
+		expect(element.refitTerminal).toHaveBeenCalled()
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal visible pending pty changes', () => {
-		spyOn(this.element, 'refitTerminal')
-		spyOn(this.element, 'setMainBackgroundColor')
-		spyOn(this.element, 'restartPtyProcess')
-		spyOn(this.element.terminal, 'setOption')
-		this.element.terminalDivInitiallyVisible = true
-		this.element.pendingTerminalProfileOptions.command = 'somecommand'
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.setMainBackgroundColor).toHaveBeenCalled()
-		expect(this.element.terminal.setOption).not.toHaveBeenCalled()
-		expect(this.element.restartPtyProcess).toHaveBeenCalled()
-		expect(this.element.refitTerminal).toHaveBeenCalled()
+		spyOn(element, 'refitTerminal')
+		spyOn(element, 'setMainBackgroundColor')
+		spyOn(element, 'restartPtyProcess')
+		spyOn(element.terminal, 'setOption')
+		element.terminalDivInitiallyVisible = true
+		element.pendingTerminalProfileOptions.command = 'somecommand'
+		element.applyPendingTerminalProfileOptions()
+		expect(element.setMainBackgroundColor).toHaveBeenCalled()
+		expect(element.terminal.setOption).not.toHaveBeenCalled()
+		expect(element.restartPtyProcess).toHaveBeenCalled()
+		expect(element.refitTerminal).toHaveBeenCalled()
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal visible pending xtermOptions and pty changes', () => {
-		spyOn(this.element, 'refitTerminal')
-		spyOn(this.element, 'setMainBackgroundColor')
-		spyOn(this.element, 'restartPtyProcess')
-		spyOn(this.element.terminal, 'setOption')
-		this.element.terminalDivInitiallyVisible = true
-		this.element.pendingTerminalProfileOptions.xtermOptions = {
+		spyOn(element, 'refitTerminal')
+		spyOn(element, 'setMainBackgroundColor')
+		spyOn(element, 'restartPtyProcess')
+		spyOn(element.terminal, 'setOption')
+		element.terminalDivInitiallyVisible = true
+		element.pendingTerminalProfileOptions.xtermOptions = {
 			cursorBlink: true,
 		}
-		this.element.pendingTerminalProfileOptions.command = 'somecommand'
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.setMainBackgroundColor).toHaveBeenCalled()
-		expect(this.element.terminal.setOption).toHaveBeenCalled()
-		expect(this.element.restartPtyProcess).toHaveBeenCalled()
-		expect(this.element.refitTerminal).toHaveBeenCalled()
+		element.pendingTerminalProfileOptions.command = 'somecommand'
+		element.applyPendingTerminalProfileOptions()
+		expect(element.setMainBackgroundColor).toHaveBeenCalled()
+		expect(element.terminal.setOption).toHaveBeenCalled()
+		expect(element.restartPtyProcess).toHaveBeenCalled()
+		expect(element.refitTerminal).toHaveBeenCalled()
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal not visible pending xtermOptions and pty changes kept', () => {
-		spyOn(this.element, 'refitTerminal')
-		this.element.terminalDivInitiallyVisible = false
-		this.element.pendingTerminalProfileOptions.xtermOptions = {
+		spyOn(element, 'refitTerminal')
+		element.terminalDivInitiallyVisible = false
+		element.pendingTerminalProfileOptions.xtermOptions = {
 			cursorBlink: true,
 		}
-		this.element.pendingTerminalProfileOptions.command = 'somecommand'
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.pendingTerminalProfileOptions).toEqual({
+		element.pendingTerminalProfileOptions.command = 'somecommand'
+		element.applyPendingTerminalProfileOptions()
+		expect(element.pendingTerminalProfileOptions).toEqual({
 			xtermOptions: {
 				cursorBlink: true,
 			},
@@ -2333,63 +2331,63 @@ describe('XTerminalElement', () => {
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal visible pending xtermOptions and pty changes removed', () => {
-		spyOn(this.element, 'refitTerminal')
-		this.element.terminalDivInitiallyVisible = true
-		this.element.pendingTerminalProfileOptions.xtermOptions = {
+		spyOn(element, 'refitTerminal')
+		element.terminalDivInitiallyVisible = true
+		element.pendingTerminalProfileOptions.xtermOptions = {
 			cursorBlink: true,
 		}
-		this.element.pendingTerminalProfileOptions.command = 'somecommand'
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.pendingTerminalProfileOptions).toEqual({})
+		element.pendingTerminalProfileOptions.command = 'somecommand'
+		element.applyPendingTerminalProfileOptions()
+		expect(element.pendingTerminalProfileOptions).toEqual({})
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal not visible x-terminal options removed', () => {
-		spyOn(this.element, 'refitTerminal')
-		this.element.terminalDivInitiallyVisible = false
-		this.element.pendingTerminalProfileOptions.leaveOpenAfterExit = true
-		this.element.pendingTerminalProfileOptions.relaunchTerminalOnStartup = true
-		this.element.pendingTerminalProfileOptions.title = 'foo'
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.pendingTerminalProfileOptions).toEqual({})
+		spyOn(element, 'refitTerminal')
+		element.terminalDivInitiallyVisible = false
+		element.pendingTerminalProfileOptions.leaveOpenAfterExit = true
+		element.pendingTerminalProfileOptions.relaunchTerminalOnStartup = true
+		element.pendingTerminalProfileOptions.title = 'foo'
+		element.applyPendingTerminalProfileOptions()
+		expect(element.pendingTerminalProfileOptions).toEqual({})
 	})
 
 	it('applyPendingTerminalProfileOptions() terminal visible x-terminal options removed', () => {
-		spyOn(this.element, 'refitTerminal')
-		this.element.terminalDivInitiallyVisible = true
-		this.element.pendingTerminalProfileOptions.leaveOpenAfterExit = true
-		this.element.pendingTerminalProfileOptions.relaunchTerminalOnStartup = true
-		this.element.pendingTerminalProfileOptions.title = 'foo'
-		this.element.applyPendingTerminalProfileOptions()
-		expect(this.element.pendingTerminalProfileOptions).toEqual({})
+		spyOn(element, 'refitTerminal')
+		element.terminalDivInitiallyVisible = true
+		element.pendingTerminalProfileOptions.leaveOpenAfterExit = true
+		element.pendingTerminalProfileOptions.relaunchTerminalOnStartup = true
+		element.pendingTerminalProfileOptions.title = 'foo'
+		element.applyPendingTerminalProfileOptions()
+		expect(element.pendingTerminalProfileOptions).toEqual({})
 	})
 
 	it('queueNewProfileChanges() no previous changes', () => {
-		spyOn(this.element, 'applyPendingTerminalProfileOptions')
+		spyOn(element, 'applyPendingTerminalProfileOptions')
 		const profileChanges = {
 			command: 'somecommand',
 		}
-		this.element.queueNewProfileChanges(profileChanges)
-		expect(this.element.pendingTerminalProfileOptions).toEqual(profileChanges)
+		element.queueNewProfileChanges(profileChanges)
+		expect(element.pendingTerminalProfileOptions).toEqual(profileChanges)
 	})
 
 	it('queueNewProfileChanges() previous command change made', () => {
-		spyOn(this.element, 'applyPendingTerminalProfileOptions')
-		this.element.pendingTerminalProfileOptions.command = 'somecommand'
+		spyOn(element, 'applyPendingTerminalProfileOptions')
+		element.pendingTerminalProfileOptions.command = 'somecommand'
 		const profileChanges = {
 			command: 'someothercommand',
 		}
-		this.element.queueNewProfileChanges(profileChanges)
-		expect(this.element.pendingTerminalProfileOptions).toEqual(profileChanges)
+		element.queueNewProfileChanges(profileChanges)
+		expect(element.pendingTerminalProfileOptions).toEqual(profileChanges)
 	})
 
 	it('queueNewProfileChanges() another setting', () => {
-		spyOn(this.element, 'applyPendingTerminalProfileOptions')
-		this.element.pendingTerminalProfileOptions.command = 'somecommand'
+		spyOn(element, 'applyPendingTerminalProfileOptions')
+		element.pendingTerminalProfileOptions.command = 'somecommand'
 		const profileChanges = {
 			args: ['--foo', '--bar', '--baz'],
 		}
-		this.element.queueNewProfileChanges(profileChanges)
-		expect(this.element.pendingTerminalProfileOptions).toEqual({
+		element.queueNewProfileChanges(profileChanges)
+		expect(element.pendingTerminalProfileOptions).toEqual({
 			command: 'somecommand',
 			args: ['--foo', '--bar', '--baz'],
 		})
@@ -2425,13 +2423,13 @@ describe('XTerminalElement', () => {
 				cursorBlink: true,
 			},
 		}
-		spyOn(this.element.model, 'getProfile').and.returnValue(profile)
-		spyOn(this.element.model, 'applyProfileChanges')
-		this.element.profilesSingleton.emitter.emit(
+		spyOn(element.model, 'getProfile').and.returnValue(profile)
+		spyOn(element.model, 'applyProfileChanges')
+		element.profilesSingleton.emitter.emit(
 			'did-reset-base-profile',
 			profile,
 		)
-		expect(this.element.model.applyProfileChanges).toHaveBeenCalledWith({})
+		expect(element.model.applyProfileChanges).toHaveBeenCalledWith({})
 	})
 
 	it('base profile changed, font size changed, xterm options remained the same', () => {
@@ -2464,15 +2462,15 @@ describe('XTerminalElement', () => {
 				cursorBlink: true,
 			},
 		}
-		const newBaseProfile = this.element.profilesSingleton.deepClone(profile)
+		const newBaseProfile = element.profilesSingleton.deepClone(profile)
 		newBaseProfile.fontSize = 15
-		spyOn(this.element.model, 'getProfile').and.returnValue(profile)
-		spyOn(this.element.model, 'applyProfileChanges')
-		this.element.profilesSingleton.emitter.emit(
+		spyOn(element.model, 'getProfile').and.returnValue(profile)
+		spyOn(element.model, 'applyProfileChanges')
+		element.profilesSingleton.emitter.emit(
 			'did-reset-base-profile',
 			newBaseProfile,
 		)
-		expect(this.element.model.applyProfileChanges).toHaveBeenCalledWith({
+		expect(element.model.applyProfileChanges).toHaveBeenCalledWith({
 			fontSize: 15,
 		})
 	})
@@ -2507,17 +2505,17 @@ describe('XTerminalElement', () => {
 				cursorBlink: true,
 			},
 		}
-		const newBaseProfile = this.element.profilesSingleton.deepClone(profile)
+		const newBaseProfile = element.profilesSingleton.deepClone(profile)
 		newBaseProfile.xtermOptions = {
 			cursorBlink: false,
 		}
-		spyOn(this.element.model, 'getProfile').and.returnValue(profile)
-		spyOn(this.element.model, 'applyProfileChanges')
-		this.element.profilesSingleton.emitter.emit(
+		spyOn(element.model, 'getProfile').and.returnValue(profile)
+		spyOn(element.model, 'applyProfileChanges')
+		element.profilesSingleton.emitter.emit(
 			'did-reset-base-profile',
 			newBaseProfile,
 		)
-		expect(this.element.model.applyProfileChanges).toHaveBeenCalledWith({
+		expect(element.model.applyProfileChanges).toHaveBeenCalledWith({
 			xtermOptions: {
 				cursorBlink: false,
 			},
@@ -2554,18 +2552,18 @@ describe('XTerminalElement', () => {
 				cursorBlink: true,
 			},
 		}
-		const newBaseProfile = this.element.profilesSingleton.deepClone(profile)
+		const newBaseProfile = element.profilesSingleton.deepClone(profile)
 		newBaseProfile.fontSize = 15
 		newBaseProfile.xtermOptions = {
 			cursorBlink: false,
 		}
-		spyOn(this.element.model, 'getProfile').and.returnValue(profile)
-		spyOn(this.element.model, 'applyProfileChanges')
-		this.element.profilesSingleton.emitter.emit(
+		spyOn(element.model, 'getProfile').and.returnValue(profile)
+		spyOn(element.model, 'applyProfileChanges')
+		element.profilesSingleton.emitter.emit(
 			'did-reset-base-profile',
 			newBaseProfile,
 		)
-		expect(this.element.model.applyProfileChanges).toHaveBeenCalledWith({
+		expect(element.model.applyProfileChanges).toHaveBeenCalledWith({
 			fontSize: 15,
 			xtermOptions: {
 				cursorBlink: false,
@@ -2604,14 +2602,14 @@ describe('XTerminalElement', () => {
 				cursorBlink: true,
 			},
 		}
-		const newBaseProfile = this.element.profilesSingleton.deepClone(profile)
+		const newBaseProfile = element.profilesSingleton.deepClone(profile)
 		newBaseProfile.command = 'someothercommand'
-		spyOn(this.element.model, 'getProfile').and.returnValue(profile)
-		spyOn(this.element.model, 'applyProfileChanges')
-		this.element.profilesSingleton.emitter.emit(
+		spyOn(element.model, 'getProfile').and.returnValue(profile)
+		spyOn(element.model, 'applyProfileChanges')
+		element.profilesSingleton.emitter.emit(
 			'did-reset-base-profile',
 			newBaseProfile,
 		)
-		expect(this.element.model.applyProfileChanges).toHaveBeenCalledWith({})
+		expect(element.model.applyProfileChanges).toHaveBeenCalledWith({})
 	})
 })

--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -45,7 +45,7 @@ describe('XTerminalModel', () => {
 		pane = jasmine.createSpyObj('pane',
 			['destroyItem', 'getActiveItem'])
 		element = jasmine.createSpyObj('element',
-			['destroy', 'refitTerminal', 'focusOnTerminal', 'clickOnCurrentAnchor', 'getCurrentAnchorHref', 'restartPtyProcess'])
+			['destroy', 'refitTerminal', 'focusOnTerminal', 'clickOnCurrentAnchor', 'getCurrentAnchorHref', 'restartPtyProcess', 'clear'])
 		element.terminal = jasmine.createSpyObj('terminal',
 			['getSelection'])
 		element.ptyProcess = jasmine.createSpyObj('ptyProcess',
@@ -469,6 +469,12 @@ describe('XTerminalModel', () => {
 		const expectedText = 'some text'
 		model.pasteToTerminal(expectedText)
 		expect(model.element.ptyProcess.write.calls.allArgs()).toEqual([[expectedText]])
+	})
+
+	it('clear()', () => {
+		model.element = element
+		model.clear()
+		expect(model.element.clear).toHaveBeenCalled()
 	})
 
 	it('setActive()', async function () {

--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Emitter } from 'atom'
-
 import { configDefaults } from '../src/config'
 import { XTerminalModel, isXTerminalModel, currentItemIsXTerminalModel } from '../src/model'
 import { XTerminalProfilesSingleton } from '../src/profiles'
@@ -33,30 +31,26 @@ import temp from 'temp'
 temp.track()
 
 describe('XTerminalModel', () => {
-	this.model = null
-	this.pane = null
-	this.element = null
-	this.emitter = null
+	let model, pane, element, tmpdir
 
 	beforeEach(async () => {
 		const uri = 'x-terminal://somesessionid/'
 		spyOn(XTerminalProfilesSingleton.instance, 'generateNewUri').and.returnValue(uri)
 		const terminalsSet = new Set()
-		this.model = new XTerminalModel({
+		model = new XTerminalModel({
 			uri: uri,
 			terminals_set: terminalsSet,
 		})
-		await this.model.initializedPromise
-		this.pane = jasmine.createSpyObj('pane',
+		await model.initializedPromise
+		pane = jasmine.createSpyObj('pane',
 			['destroyItem', 'getActiveItem'])
-		this.element = jasmine.createSpyObj('element',
+		element = jasmine.createSpyObj('element',
 			['destroy', 'refitTerminal', 'focusOnTerminal', 'clickOnCurrentAnchor', 'getCurrentAnchorHref', 'restartPtyProcess'])
-		this.element.terminal = jasmine.createSpyObj('terminal',
+		element.terminal = jasmine.createSpyObj('terminal',
 			['getSelection'])
-		this.element.ptyProcess = jasmine.createSpyObj('ptyProcess',
+		element.ptyProcess = jasmine.createSpyObj('ptyProcess',
 			['write'])
-		this.emitter = new Emitter()
-		this.tmpdir = await temp.mkdir()
+		tmpdir = await temp.mkdir()
 	})
 
 	afterEach(async () => {
@@ -76,13 +70,13 @@ describe('XTerminalModel', () => {
 	it('constructor with valid cwd passed in uri', async () => {
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue({})
 		const url = XTerminalProfilesSingleton.instance.generateNewUrlFromProfileData({})
-		url.searchParams.set('cwd', this.tmpdir)
+		url.searchParams.set('cwd', tmpdir)
 		const model = new XTerminalModel({
 			uri: url.href,
 			terminals_set: new Set(),
 		})
 		await model.initializedPromise
-		expect(model.getPath()).toBe(this.tmpdir)
+		expect(model.getPath()).toBe(tmpdir)
 	})
 
 	it('use projectCwd with valid cwd passed in uri', async () => {
@@ -91,7 +85,7 @@ describe('XTerminalModel', () => {
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue({})
 		const url = XTerminalProfilesSingleton.instance.generateNewUrlFromProfileData({})
 		url.searchParams.set('projectCwd', true)
-		url.searchParams.set('cwd', this.tmpdir)
+		url.searchParams.set('cwd', tmpdir)
 		const model = new XTerminalModel({
 			uri: url.href,
 			terminals_set: new Set(),
@@ -103,7 +97,7 @@ describe('XTerminalModel', () => {
 	it('constructor with invalid cwd passed in uri', async () => {
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue({})
 		const url = XTerminalProfilesSingleton.instance.generateNewUrlFromProfileData({})
-		url.searchParams.set('cwd', path.join(this.tmpdir, 'non-existent-dir'))
+		url.searchParams.set('cwd', path.join(tmpdir, 'non-existent-dir'))
 		const model = new XTerminalModel({
 			uri: url.href,
 			terminals_set: new Set(),
@@ -114,19 +108,19 @@ describe('XTerminalModel', () => {
 
 	it('constructor with previous active item that has getPath() method', async () => {
 		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
-		previousActiveItem.getPath.and.returnValue(this.tmpdir)
+		previousActiveItem.getPath.and.returnValue(tmpdir)
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
 		const model = new XTerminalModel({
 			uri: 'x-terminal://somesessionid/',
 			terminals_set: new Set(),
 		})
 		await model.initializedPromise
-		expect(model.getPath()).toBe(this.tmpdir)
+		expect(model.getPath()).toBe(tmpdir)
 	})
 
 	it('constructor with previous active item that has getPath() method returns file path', async () => {
 		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
-		const filePath = path.join(this.tmpdir, 'somefile')
+		const filePath = path.join(tmpdir, 'somefile')
 		await fs.writeFile(filePath, '')
 		previousActiveItem.getPath.and.returnValue(filePath)
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
@@ -135,12 +129,12 @@ describe('XTerminalModel', () => {
 			terminals_set: new Set(),
 		})
 		await model.initializedPromise
-		expect(model.getPath()).toBe(this.tmpdir)
+		expect(model.getPath()).toBe(tmpdir)
 	})
 
 	it('constructor with previous active item that has getPath() returning invalid path', async () => {
 		const previousActiveItem = jasmine.createSpyObj('somemodel', ['getPath'])
-		previousActiveItem.getPath.and.returnValue(path.join(this.tmpdir, 'non-existent-dir'))
+		previousActiveItem.getPath.and.returnValue(path.join(tmpdir, 'non-existent-dir'))
 		spyOn(atom.workspace, 'getActivePaneItem').and.returnValue(previousActiveItem)
 		const model = new XTerminalModel({
 			uri: 'x-terminal://somesessionid/',
@@ -205,7 +199,7 @@ describe('XTerminalModel', () => {
 
 	it('serialize() cwd set in uri', async () => {
 		const url = XTerminalProfilesSingleton.instance.generateNewUrlFromProfileData({})
-		url.searchParams.set('cwd', this.tmpdir)
+		url.searchParams.set('cwd', tmpdir)
 		const model = new XTerminalModel({
 			uri: url.href,
 			terminals_set: new Set(),
@@ -217,41 +211,41 @@ describe('XTerminalModel', () => {
 			version: '2017-09-17',
 			uri: url2.href,
 		}
-		expect(url2.searchParams.get('cwd')).toEqual(this.tmpdir)
+		expect(url2.searchParams.get('cwd')).toEqual(tmpdir)
 		expect(model.serialize()).toEqual(expected)
 	})
 
 	it('destroy() check element is destroyed when set', () => {
-		this.model.element = this.element
-		this.model.destroy()
-		expect(this.model.element.destroy).toHaveBeenCalled()
+		model.element = element
+		model.destroy()
+		expect(model.element.destroy).toHaveBeenCalled()
 	})
 
 	it('destroy() check model removed from terminals_set', () => {
-		spyOn(this.model.terminals_set, 'delete').and.callThrough()
-		this.model.destroy()
-		expect(this.model.terminals_set.delete.calls.allArgs()).toEqual([[this.model]])
+		spyOn(model.terminals_set, 'delete').and.callThrough()
+		model.destroy()
+		expect(model.terminals_set.delete.calls.allArgs()).toEqual([[model]])
 	})
 
 	it('getTitle() with default title', () => {
-		expect(this.model.getTitle()).toBe('X Terminal')
+		expect(model.getTitle()).toBe('X Terminal')
 	})
 
 	it('getTitle() with new title', () => {
 		const expected = 'some new title'
-		this.model.title = expected
-		expect(this.model.getTitle()).toBe(expected)
+		model.title = expected
+		expect(model.getTitle()).toBe(expected)
 	})
 
 	it('getTitle() when active', () => {
-		spyOn(this.model, 'isActiveTerminal').and.returnValue(true)
-		expect(this.model.getTitle()).toBe('* X Terminal')
+		spyOn(model, 'isActiveTerminal').and.returnValue(true)
+		expect(model.getTitle()).toBe('* X Terminal')
 	})
 
 	it('getElement()', () => {
 		const expected = { somekey: 'somevalue' }
-		this.model.element = expected
-		expect(this.model.getElement()).toBe(expected)
+		model.element = expected
+		expect(model.getElement()).toBe(expected)
 	})
 
 	it('getURI()', async () => {
@@ -266,108 +260,108 @@ describe('XTerminalModel', () => {
 	})
 
 	it('getLongTitle() with default title', () => {
-		expect(this.model.getLongTitle()).toBe('X Terminal')
+		expect(model.getLongTitle()).toBe('X Terminal')
 	})
 
 	it('getLongTitle() with new title', () => {
 		const expected = 'X Terminal (some new title)'
-		this.model.title = 'some new title'
-		expect(this.model.getLongTitle()).toBe(expected)
+		model.title = 'some new title'
+		expect(model.getLongTitle()).toBe(expected)
 	})
 
 	it('onDidChangeTitle()', () => {
 		let callbackCalled = false
-		const disposable = this.model.onDidChangeTitle(() => {
+		const disposable = model.onDidChangeTitle(() => {
 			callbackCalled = true
 		})
-		this.model.emitter.emit('did-change-title')
+		model.emitter.emit('did-change-title')
 		expect(callbackCalled).toBe(true)
 		disposable.dispose()
 	})
 
 	it('getIconName()', () => {
-		expect(this.model.getIconName()).toBe('terminal')
+		expect(model.getIconName()).toBe('terminal')
 	})
 
 	it('isModified()', () => {
-		expect(this.model.isModified()).toBe(false)
+		expect(model.isModified()).toBe(false)
 	})
 
 	it('isModified() modified attribute set to true', () => {
-		this.model.modified = true
-		expect(this.model.isModified()).toBe(true)
+		model.modified = true
+		expect(model.isModified()).toBe(true)
 	})
 
 	it('getPath()', () => {
-		expect(this.model.getPath()).toBe(configDefaults.cwd)
+		expect(model.getPath()).toBe(configDefaults.cwd)
 	})
 
 	it('getPath() cwd set', () => {
 		const expected = '/some/dir'
-		this.model.profile.cwd = expected
-		expect(this.model.getPath()).toBe(expected)
+		model.profile.cwd = expected
+		expect(model.getPath()).toBe(expected)
 	})
 
 	it('onDidChangeModified()', () => {
 		let callbackCalled = false
-		const disposable = this.model.onDidChangeModified(() => {
+		const disposable = model.onDidChangeModified(() => {
 			callbackCalled = true
 		})
-		this.model.emitter.emit('did-change-modified')
+		model.emitter.emit('did-change-modified')
 		expect(callbackCalled).toBe(true)
 		disposable.dispose()
 	})
 
 	it('handleNewDataArrival() current item is active item', () => {
-		this.pane.getActiveItem.and.returnValue(this.model)
-		this.model.pane = this.pane
-		this.model.handleNewDataArrival()
-		expect(this.model.modified).toBe(false)
+		pane.getActiveItem.and.returnValue(model)
+		model.pane = pane
+		model.handleNewDataArrival()
+		expect(model.modified).toBe(false)
 	})
 
 	it('handleNewDataArrival() current item is not active item', () => {
-		this.pane.getActiveItem.and.returnValue({})
-		this.model.pane = this.pane
-		this.model.handleNewDataArrival()
-		expect(this.model.modified).toBe(true)
+		pane.getActiveItem.and.returnValue({})
+		model.pane = pane
+		model.handleNewDataArrival()
+		expect(model.modified).toBe(true)
 	})
 
 	it('handleNewDataArrival() current item is not in any pane', () => {
-		this.model.pane = null
-		this.model.handleNewDataArrival()
-		expect(this.model.modified).toBe(true)
+		model.pane = null
+		model.handleNewDataArrival()
+		expect(model.modified).toBe(true)
 	})
 
 	it('handleNewDataArrival() model initially has no pane set', () => {
-		this.pane.getActiveItem.and.returnValue({})
-		spyOn(atom.workspace, 'paneForItem').and.returnValue(this.pane)
-		this.model.handleNewDataArrival()
+		pane.getActiveItem.and.returnValue({})
+		spyOn(atom.workspace, 'paneForItem').and.returnValue(pane)
+		model.handleNewDataArrival()
 		expect(atom.workspace.paneForItem).toHaveBeenCalled()
 	})
 
 	it('handleNewDataArrival() modified value of false not changed', () => {
-		this.pane.getActiveItem.and.returnValue(this.model)
-		this.model.pane = this.pane
-		spyOn(this.model.emitter, 'emit')
-		this.model.handleNewDataArrival()
-		expect(this.model.emitter.emit).toHaveBeenCalledTimes(0)
+		pane.getActiveItem.and.returnValue(model)
+		model.pane = pane
+		spyOn(model.emitter, 'emit')
+		model.handleNewDataArrival()
+		expect(model.emitter.emit).toHaveBeenCalledTimes(0)
 	})
 
 	it('handleNewDataArrival() modified value of true not changed', () => {
-		this.pane.getActiveItem.and.returnValue({})
-		this.model.pane = this.pane
-		this.model.modified = true
-		spyOn(this.model.emitter, 'emit')
-		this.model.handleNewDataArrival()
-		expect(this.model.emitter.emit).toHaveBeenCalledTimes(0)
+		pane.getActiveItem.and.returnValue({})
+		model.pane = pane
+		model.modified = true
+		spyOn(model.emitter, 'emit')
+		model.handleNewDataArrival()
+		expect(model.emitter.emit).toHaveBeenCalledTimes(0)
 	})
 
 	it('handleNewDataArrival() modified value changed', () => {
-		this.pane.getActiveItem.and.returnValue({})
-		this.model.pane = this.pane
-		spyOn(this.model.emitter, 'emit')
-		this.model.handleNewDataArrival()
-		expect(this.model.emitter.emit).toHaveBeenCalled()
+		pane.getActiveItem.and.returnValue({})
+		model.pane = pane
+		spyOn(model.emitter, 'emit')
+		model.handleNewDataArrival()
+		expect(model.emitter.emit).toHaveBeenCalled()
 	})
 
 	it('getSessionId()', async () => {
@@ -397,84 +391,84 @@ describe('XTerminalModel', () => {
 
 	it('refitTerminal() without element set', () => {
 		// Should just work.
-		this.model.refitTerminal()
+		model.refitTerminal()
 	})
 
 	it('refitTerminal() with element set', () => {
-		this.model.element = this.element
-		this.model.refitTerminal()
-		expect(this.model.element.refitTerminal).toHaveBeenCalled()
+		model.element = element
+		model.refitTerminal()
+		expect(model.element.refitTerminal).toHaveBeenCalled()
 	})
 
 	it('focusOnTerminal()', () => {
-		this.model.element = this.element
-		this.model.focusOnTerminal()
-		expect(this.model.element.focusOnTerminal).toHaveBeenCalled()
+		model.element = element
+		model.focusOnTerminal()
+		expect(model.element.focusOnTerminal).toHaveBeenCalled()
 	})
 
 	it('focusOnTerminal() reset modified value old modified value was false', () => {
-		this.model.element = this.element
-		this.model.focusOnTerminal()
-		expect(this.model.modified).toBe(false)
+		model.element = element
+		model.focusOnTerminal()
+		expect(model.modified).toBe(false)
 	})
 
 	it('focusOnTerminal() reset modified value old modified value was true', () => {
-		this.model.element = this.element
-		this.model.modified = true
-		this.model.focusOnTerminal()
-		expect(this.model.modified).toBe(false)
+		model.element = element
+		model.modified = true
+		model.focusOnTerminal()
+		expect(model.modified).toBe(false)
 	})
 
 	it('focusOnTerminal() no event emitted old modified value was false', () => {
-		this.model.element = this.element
-		spyOn(this.model.emitter, 'emit')
-		this.model.focusOnTerminal()
-		expect(this.model.emitter.emit).toHaveBeenCalledTimes(0)
+		model.element = element
+		spyOn(model.emitter, 'emit')
+		model.focusOnTerminal()
+		expect(model.emitter.emit).toHaveBeenCalledTimes(0)
 	})
 
 	it('focusOnTerminal() event emitted old modified value was true', () => {
-		this.model.element = this.element
-		this.model.modified = true
-		spyOn(this.model.emitter, 'emit')
-		this.model.focusOnTerminal()
-		expect(this.model.emitter.emit).toHaveBeenCalled()
+		model.element = element
+		model.modified = true
+		spyOn(model.emitter, 'emit')
+		model.focusOnTerminal()
+		expect(model.emitter.emit).toHaveBeenCalled()
 	})
 
 	it('exit()', () => {
-		this.model.pane = this.pane
-		this.model.exit()
-		expect(this.model.pane.destroyItem.calls.allArgs()).toEqual([[this.model, true]])
+		model.pane = pane
+		model.exit()
+		expect(model.pane.destroyItem.calls.allArgs()).toEqual([[model, true]])
 	})
 
 	it('restartPtyProcess() no element set', () => {
-		this.model.restartPtyProcess()
-		expect(this.element.restartPtyProcess).not.toHaveBeenCalled()
+		model.restartPtyProcess()
+		expect(element.restartPtyProcess).not.toHaveBeenCalled()
 	})
 
 	it('restartPtyProcess() element set', () => {
-		this.model.element = this.element
-		this.model.restartPtyProcess()
-		expect(this.model.element.restartPtyProcess).toHaveBeenCalled()
+		model.element = element
+		model.restartPtyProcess()
+		expect(model.element.restartPtyProcess).toHaveBeenCalled()
 	})
 
 	it('copyFromTerminal()', () => {
-		this.model.element = this.element
-		this.model.copyFromTerminal()
-		expect(this.model.element.terminal.getSelection).toHaveBeenCalled()
+		model.element = element
+		model.copyFromTerminal()
+		expect(model.element.terminal.getSelection).toHaveBeenCalled()
 	})
 
 	it('runCommand(cmd)', () => {
-		this.model.element = this.element
+		model.element = element
 		const expectedText = 'some text'
-		this.model.runCommand(expectedText)
-		expect(this.model.element.ptyProcess.write.calls.allArgs()).toEqual([[expectedText + (process.platform === 'win32' ? '\r' : '\n')]])
+		model.runCommand(expectedText)
+		expect(model.element.ptyProcess.write.calls.allArgs()).toEqual([[expectedText + (process.platform === 'win32' ? '\r' : '\n')]])
 	})
 
 	it('pasteToTerminal(text)', () => {
-		this.model.element = this.element
+		model.element = element
 		const expectedText = 'some text'
-		this.model.pasteToTerminal(expectedText)
-		expect(this.model.element.ptyProcess.write.calls.allArgs()).toEqual([[expectedText]])
+		model.pasteToTerminal(expectedText)
+		expect(model.element.ptyProcess.write.calls.allArgs()).toEqual([[expectedText]])
 	})
 
 	it('setActive()', async function () {
@@ -505,117 +499,117 @@ describe('XTerminalModel', () => {
 	describe('setNewPane', () => {
 		it('(mock)', async () => {
 			const expected = { getContainer: () => ({ getLocation: () => {} }) }
-			this.model.setNewPane(expected)
-			expect(this.model.pane).toBe(expected)
-			expect(this.model.dock).toBe(null)
+			model.setNewPane(expected)
+			expect(model.pane).toBe(expected)
+			expect(model.dock).toBe(null)
 		})
 
 		it('(center)', async () => {
 			const pane = atom.workspace.getCenter().getActivePane()
-			this.model.setNewPane(pane)
-			expect(this.model.pane).toBe(pane)
-			expect(this.model.dock).toBe(null)
+			model.setNewPane(pane)
+			expect(model.pane).toBe(pane)
+			expect(model.dock).toBe(null)
 		})
 
 		it('(left)', async () => {
 			const dock = atom.workspace.getLeftDock()
 			const pane = dock.getActivePane()
-			this.model.setNewPane(pane)
-			expect(this.model.pane).toBe(pane)
-			expect(this.model.dock).toBe(dock)
+			model.setNewPane(pane)
+			expect(model.pane).toBe(pane)
+			expect(model.dock).toBe(dock)
 		})
 
 		it('(right)', async () => {
 			const dock = atom.workspace.getRightDock()
 			const pane = dock.getActivePane()
-			this.model.setNewPane(pane)
-			expect(this.model.pane).toBe(pane)
-			expect(this.model.dock).toBe(dock)
+			model.setNewPane(pane)
+			expect(model.pane).toBe(pane)
+			expect(model.dock).toBe(dock)
 		})
 
 		it('(bottom)', async () => {
 			const dock = atom.workspace.getBottomDock()
 			const pane = dock.getActivePane()
-			this.model.setNewPane(pane)
-			expect(this.model.pane).toBe(pane)
-			expect(this.model.dock).toBe(dock)
+			model.setNewPane(pane)
+			expect(model.pane).toBe(pane)
+			expect(model.dock).toBe(dock)
 		})
 	})
 
 	it('isVisible() in pane', () => {
 		const pane = atom.workspace.getCenter().getActivePane()
-		this.model.setNewPane(pane)
-		expect(this.model.isVisible()).toBe(false)
-		pane.setActiveItem(this.model)
-		expect(this.model.isVisible()).toBe(true)
+		model.setNewPane(pane)
+		expect(model.isVisible()).toBe(false)
+		pane.setActiveItem(model)
+		expect(model.isVisible()).toBe(true)
 	})
 
 	it('isVisible() in dock', () => {
 		const dock = atom.workspace.getBottomDock()
 		const pane = dock.getActivePane()
-		this.model.setNewPane(pane)
-		pane.setActiveItem(this.model)
-		expect(this.model.isVisible()).toBe(false)
+		model.setNewPane(pane)
+		pane.setActiveItem(model)
+		expect(model.isVisible()).toBe(false)
 		dock.show()
-		expect(this.model.isVisible()).toBe(true)
+		expect(model.isVisible()).toBe(true)
 	})
 
 	it('isActiveTerminal() visible and active', () => {
-		this.model.activeIndex = 0
-		spyOn(this.model, 'isVisible').and.returnValue(true)
-		expect(this.model.isActiveTerminal()).toBe(true)
+		model.activeIndex = 0
+		spyOn(model, 'isVisible').and.returnValue(true)
+		expect(model.isActiveTerminal()).toBe(true)
 	})
 
 	it('isActiveTerminal() visible and not active', () => {
-		this.model.activeIndex = 1
-		spyOn(this.model, 'isVisible').and.returnValue(true)
-		expect(this.model.isActiveTerminal()).toBe(false)
+		model.activeIndex = 1
+		spyOn(model, 'isVisible').and.returnValue(true)
+		expect(model.isActiveTerminal()).toBe(false)
 	})
 
 	it('isActiveTerminal() invisible and active', () => {
-		this.model.activeIndex = 0
-		spyOn(this.model, 'isVisible').and.returnValue(false)
-		expect(this.model.isActiveTerminal()).toBe(false)
+		model.activeIndex = 0
+		spyOn(model, 'isVisible').and.returnValue(false)
+		expect(model.isActiveTerminal()).toBe(false)
 	})
 
 	it('isActiveTerminal() allowHiddenToStayActive', () => {
 		atom.config.set('x-terminal.terminalSettings.allowHiddenToStayActive', true)
-		this.model.activeIndex = 0
-		spyOn(this.model, 'isVisible').and.returnValue(false)
-		expect(this.model.isActiveTerminal()).toBe(true)
+		model.activeIndex = 0
+		spyOn(model, 'isVisible').and.returnValue(false)
+		expect(model.isActiveTerminal()).toBe(true)
 	})
 
 	it('toggleProfileMenu()', () => {
-		this.model.element = jasmine.createSpyObj('element', ['toggleProfileMenu'])
-		this.model.toggleProfileMenu()
-		expect(this.model.element.toggleProfileMenu).toHaveBeenCalled()
+		model.element = jasmine.createSpyObj('element', ['toggleProfileMenu'])
+		model.toggleProfileMenu()
+		expect(model.element.toggleProfileMenu).toHaveBeenCalled()
 	})
 
 	it('getProfile()', () => {
 		const mock = jasmine.createSpy('mock')
-		this.model.profile = mock
-		expect(this.model.getProfile()).toBe(mock)
+		model.profile = mock
+		expect(model.getProfile()).toBe(mock)
 	})
 
 	it('applyProfileChanges() element queueNewProfileChanges() called', () => {
-		this.model.element = jasmine.createSpyObj('element', ['queueNewProfileChanges'])
-		this.model.applyProfileChanges({})
-		expect(this.model.element.queueNewProfileChanges).toHaveBeenCalled()
+		model.element = jasmine.createSpyObj('element', ['queueNewProfileChanges'])
+		model.applyProfileChanges({})
+		expect(model.element.queueNewProfileChanges).toHaveBeenCalled()
 	})
 
 	it('applyProfileChanges() profileChanges = {}', () => {
-		this.model.element = jasmine.createSpyObj('element', ['queueNewProfileChanges'])
-		const expected = this.model.profilesSingleton.deepClone(this.model.profile)
-		this.model.applyProfileChanges({})
-		expect(this.model.profile).toEqual(expected)
+		model.element = jasmine.createSpyObj('element', ['queueNewProfileChanges'])
+		const expected = model.profilesSingleton.deepClone(model.profile)
+		model.applyProfileChanges({})
+		expect(model.profile).toEqual(expected)
 	})
 
 	it('applyProfileChanges() profileChanges = {fontSize: 24}', () => {
-		this.model.element = jasmine.createSpyObj('element', ['queueNewProfileChanges'])
-		const expected = this.model.profilesSingleton.deepClone(this.model.profile)
+		model.element = jasmine.createSpyObj('element', ['queueNewProfileChanges'])
+		const expected = model.profilesSingleton.deepClone(model.profile)
 		expected.fontSize = 24
-		this.model.applyProfileChanges({ fontSize: 24 })
-		expect(this.model.profile).toEqual(expected)
+		model.applyProfileChanges({ fontSize: 24 })
+		expect(model.profile).toEqual(expected)
 	})
 })
 

--- a/spec/overwrite-profile-element-spec.js
+++ b/spec/overwrite-profile-element-spec.js
@@ -22,21 +22,21 @@
 import { XTerminalOverwriteProfileElement } from '../src/overwrite-profile-element'
 
 describe('XTerminalOverwriteProfileElement', () => {
-	this.model = null
+	let model
 
 	beforeEach(() => {
-		this.model = jasmine.createSpyObj('model', ['setElement'])
+		model = jasmine.createSpyObj('model', ['setElement'])
 	})
 
 	it('initialize()', () => {
 		const element = new XTerminalOverwriteProfileElement()
-		element.initialize(this.model)
+		element.initialize(model)
 		expect(element.promptButtonsDiv.childElementCount).toBe(0)
 	})
 
 	it('setNewPrompt()', () => {
 		const element = new XTerminalOverwriteProfileElement()
-		element.initialize(this.model)
+		element.initialize(model)
 		const profileName = 'foo'
 		const confirmHandler = () => {}
 		const cancelHandler = () => {}

--- a/spec/overwrite-profile-model-spec.js
+++ b/spec/overwrite-profile-model-spec.js
@@ -22,10 +22,10 @@
 import { XTerminalOverwriteProfileModel } from '../src/overwrite-profile-model'
 
 describe('XTerminalOverwriteProfileModel', () => {
-	this.atomXtermSaveProfileModel = null
+	let atomXtermSaveProfileModel
 
 	beforeEach(() => {
-		this.atomXtermSaveProfileModel = jasmine.createSpyObj(
+		atomXtermSaveProfileModel = jasmine.createSpyObj(
 			'atomXtermSaveProfileModel',
 			[
 				'promptForNewProfileName',
@@ -34,29 +34,29 @@ describe('XTerminalOverwriteProfileModel', () => {
 	})
 
 	it('constructor()', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		expect(model).not.toBeNull()
 	})
 
 	it('getTitle()', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		expect(model.getTitle()).toBe('X Terminal Overwrite Profile Model')
 	})
 
 	it('getElement()', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		expect(model.getElement()).toBeNull()
 	})
 
 	it('setElement()', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		const element = jasmine.createSpy('atomXtermOverwriteProfileElement')
 		model.setElement(element)
 		expect(model.getElement()).toBe(element)
 	})
 
 	it('close() panel is not visible', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(false)
 		model.close('foo', 'bar')
@@ -65,7 +65,7 @@ describe('XTerminalOverwriteProfileModel', () => {
 	})
 
 	it('close() panel is visible', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.close('foo', 'bar')
@@ -74,7 +74,7 @@ describe('XTerminalOverwriteProfileModel', () => {
 	})
 
 	it('close() reprompt panel is not visible', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(false)
 		model.close('foo', 'bar', true)
@@ -83,7 +83,7 @@ describe('XTerminalOverwriteProfileModel', () => {
 	})
 
 	it('close() reprompt panel is visible', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.close('foo', 'bar', true)
@@ -92,7 +92,7 @@ describe('XTerminalOverwriteProfileModel', () => {
 	})
 
 	it('promptOverwrite() panel is shown', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		model.panel = jasmine.createSpyObj('panel', ['show', 'isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.element = jasmine.createSpyObj('atomXtermDeleteProfileElement', ['setNewPrompt'])
@@ -101,7 +101,7 @@ describe('XTerminalOverwriteProfileModel', () => {
 	})
 
 	it('promptOverwrite() new prompt is set', () => {
-		const model = new XTerminalOverwriteProfileModel(this.atomXtermSaveProfileModel)
+		const model = new XTerminalOverwriteProfileModel(atomXtermSaveProfileModel)
 		model.panel = jasmine.createSpyObj('panel', ['show', 'isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.element = jasmine.createSpyObj('atomXtermDeleteProfileElement', ['setNewPrompt'])

--- a/spec/profile-menu-element-spec.js
+++ b/spec/profile-menu-element-spec.js
@@ -22,7 +22,7 @@
 import { XTerminalProfileMenuElement } from '../src/profile-menu-element'
 
 describe('XTerminalProfileMenuElement', () => {
-	this.element = null
+	let element
 
 	beforeEach(async () => {
 		const model = jasmine.createSpyObj(
@@ -53,173 +53,173 @@ describe('XTerminalProfileMenuElement', () => {
 		)
 		model.getXTerminalModel.and.returnValue(model.atomXtermModel)
 		model.getXTerminalModelElement.and.returnValue(mock)
-		this.element = new XTerminalProfileMenuElement()
-		this.element.initialize(model)
-		await this.element.initializedPromise
+		element = new XTerminalProfileMenuElement()
+		element.initialize(model)
+		await element.initializedPromise
 	})
 
 	it('initialize()', async () => {
-		await this.element.initializedPromise
+		await element.initializedPromise
 	})
 
 	it('destroy() disposables not set', () => {
-		this.element.disposables = null
-		this.element.destroy()
+		element.disposables = null
+		element.destroy()
 	})
 
 	it('destroy() disposables is set', () => {
-		this.element.disposables = jasmine.createSpyObj(
+		element.disposables = jasmine.createSpyObj(
 			'disposables',
 			[
 				'dispose',
 			],
 		)
-		this.element.destroy()
-		expect(this.element.disposables.dispose).toHaveBeenCalled()
+		element.destroy()
+		expect(element.disposables.dispose).toHaveBeenCalled()
 	})
 
 	it('getModelProfile()', () => {
 		const mock = jasmine.createSpy('mock')
-		this.element.model.atomXtermModel.profile = mock
-		expect(this.element.getModelProfile()).toBe(mock)
+		element.model.atomXtermModel.profile = mock
+		expect(element.getModelProfile()).toBe(mock)
 	})
 
 	it('getMenuElements()', () => {
-		expect(this.element.getMenuElements()).toBeTruthy()
+		expect(element.getMenuElements()).toBeTruthy()
 	})
 
 	it('getProfileMenuSettings()', () => {
-		const expected = this.element.profilesSingleton.getBaseProfile()
-		const actual = this.element.getProfileMenuSettings()
+		const expected = element.profilesSingleton.getBaseProfile()
+		const actual = element.getProfileMenuSettings()
 		expect(actual).toEqual(expected)
 	})
 
 	it('applyProfileChanges()', () => {
-		this.element.applyProfileChanges('foo')
-		expect(this.element.model.getXTerminalModel().applyProfileChanges).toHaveBeenCalledWith('foo')
+		element.applyProfileChanges('foo')
+		expect(element.model.getXTerminalModel().applyProfileChanges).toHaveBeenCalledWith('foo')
 	})
 
 	it('applyProfileChanges() profile menu hidden', () => {
-		spyOn(this.element, 'hideProfileMenu')
-		this.element.applyProfileChanges('foo')
-		expect(this.element.hideProfileMenu).toHaveBeenCalled()
+		spyOn(element, 'hideProfileMenu')
+		element.applyProfileChanges('foo')
+		expect(element.hideProfileMenu).toHaveBeenCalled()
 	})
 
 	it('restartTerminal()', () => {
-		this.element.restartTerminal()
-		expect(this.element.model.getXTerminalModelElement().restartPtyProcess).toHaveBeenCalled()
+		element.restartTerminal()
+		expect(element.model.getXTerminalModelElement().restartPtyProcess).toHaveBeenCalled()
 	})
 
 	it('restartTerminal() profile menu hidden', () => {
-		spyOn(this.element, 'hideProfileMenu')
-		this.element.restartTerminal()
-		expect(this.element.hideProfileMenu).toHaveBeenCalled()
+		spyOn(element, 'hideProfileMenu')
+		element.restartTerminal()
+		expect(element.hideProfileMenu).toHaveBeenCalled()
 	})
 
 	it('createMenuItemContainer() check id', () => {
-		const container = this.element.createMenuItemContainer('foo', 'bar', 'baz')
+		const container = element.createMenuItemContainer('foo', 'bar', 'baz')
 		expect(container.getAttribute('id')).toBe('foo')
 	})
 
 	it('createMenuItemContainer() check title', () => {
-		const container = this.element.createMenuItemContainer('foo', 'bar', 'baz')
+		const container = element.createMenuItemContainer('foo', 'bar', 'baz')
 		const titleDiv = container.querySelector('.x-terminal-profile-menu-item-title')
 		expect(titleDiv.textContent).toBe('bar')
 	})
 
 	it('createMenuItemContainer() check description', () => {
-		const container = this.element.createMenuItemContainer('foo', 'bar', 'baz')
+		const container = element.createMenuItemContainer('foo', 'bar', 'baz')
 		const descriptionDiv = container.querySelector('.x-terminal-profile-menu-item-description')
 		expect(descriptionDiv.innerHTML).toBe('<p>baz</p>\n')
 	})
 
 	it('createProfilesDropDownSelectItem() check id', async () => {
-		const select = await this.element.createProfilesDropDownSelectItem()
+		const select = await element.createProfilesDropDownSelectItem()
 		expect(select.getAttribute('id')).toBe('profiles-dropdown')
 	})
 
 	it('createProfilesDropDownSelectItem() check classList', async () => {
-		const select = await this.element.createProfilesDropDownSelectItem()
+		const select = await element.createProfilesDropDownSelectItem()
 		expect(select.classList.contains('x-terminal-profile-menu-item-select')).toBe(true)
 	})
 
 	it('createProfilesDropDown()', async () => {
-		const menuItemContainer = await this.element.createProfilesDropDown()
+		const menuItemContainer = await element.createProfilesDropDown()
 		expect(menuItemContainer.getAttribute('id')).toBe('profiles-selection')
 	})
 
 	it('createProfileMenuButtons()', () => {
-		const buttonsContainer = this.element.createProfileMenuButtons()
+		const buttonsContainer = element.createProfileMenuButtons()
 		expect(buttonsContainer.classList.contains('x-terminal-profile-menu-buttons-div')).toBe(true)
 	})
 
 	it('createButton()', () => {
-		const button = this.element.createButton()
+		const button = element.createButton()
 		expect(button.classList.contains('x-terminal-profile-menu-button')).toBe(true)
 	})
 
 	it('createTextbox()', () => {
-		const menuItemContainer = this.element.createTextbox('foo', 'bar', 'baz', 'cat', 'dog')
+		const menuItemContainer = element.createTextbox('foo', 'bar', 'baz', 'cat', 'dog')
 		expect(menuItemContainer.getAttribute('id')).toBe('foo')
 	})
 
 	it('createCheckbox()', () => {
-		const menuItemContainer = this.element.createCheckbox('foo', 'bar', 'baz', true, false)
+		const menuItemContainer = element.createCheckbox('foo', 'bar', 'baz', true, false)
 		expect(menuItemContainer.getAttribute('id')).toBe('foo')
 	})
 
 	it('isVisible() initial value', () => {
-		expect(this.element.isVisible()).toBe(false)
+		expect(element.isVisible()).toBe(false)
 	})
 
 	it('hideProfileMenu()', () => {
-		this.element.hideProfileMenu()
-		expect(this.element.style.visibility).toBe('hidden')
+		element.hideProfileMenu()
+		expect(element.style.visibility).toBe('hidden')
 	})
 
 	it('hideProfileMenu() terminal shown', () => {
-		this.element.hideProfileMenu()
-		expect(this.element.model.getXTerminalModelElement().showTerminal).toHaveBeenCalled()
+		element.hideProfileMenu()
+		expect(element.model.getXTerminalModelElement().showTerminal).toHaveBeenCalled()
 	})
 
 	it('hideProfileMenu() terminal focused', () => {
-		this.element.hideProfileMenu()
-		expect(this.element.model.getXTerminalModelElement().focusOnTerminal).toHaveBeenCalled()
+		element.hideProfileMenu()
+		expect(element.model.getXTerminalModelElement().focusOnTerminal).toHaveBeenCalled()
 	})
 
 	it('showProfileMenu()', () => {
-		this.element.showProfileMenu()
-		expect(this.element.style.visibility).toBe('visible')
+		element.showProfileMenu()
+		expect(element.style.visibility).toBe('visible')
 	})
 
 	it('showProfileMenu() terminal hidden', () => {
-		this.element.showProfileMenu()
-		expect(this.element.model.getXTerminalModelElement().hideTerminal).toHaveBeenCalled()
+		element.showProfileMenu()
+		expect(element.model.getXTerminalModelElement().hideTerminal).toHaveBeenCalled()
 	})
 
 	it('toggleProfileMenu() currently hidden', () => {
-		spyOn(this.element, 'isVisible').and.returnValue(false)
-		spyOn(this.element, 'showProfileMenu')
-		this.element.toggleProfileMenu()
-		expect(this.element.showProfileMenu).toHaveBeenCalled()
+		spyOn(element, 'isVisible').and.returnValue(false)
+		spyOn(element, 'showProfileMenu')
+		element.toggleProfileMenu()
+		expect(element.showProfileMenu).toHaveBeenCalled()
 	})
 
 	it('toggleProfileMenu() currently visible', () => {
-		spyOn(this.element, 'isVisible').and.returnValue(true)
-		spyOn(this.element, 'hideProfileMenu')
-		this.element.toggleProfileMenu()
-		expect(this.element.hideProfileMenu).toHaveBeenCalled()
+		spyOn(element, 'isVisible').and.returnValue(true)
+		spyOn(element, 'hideProfileMenu')
+		element.toggleProfileMenu()
+		expect(element.hideProfileMenu).toHaveBeenCalled()
 	})
 
 	it('getNewProfileAndChanges()', () => {
-		spyOn(this.element, 'getProfileMenuSettings').and.returnValue({
+		spyOn(element, 'getProfileMenuSettings').and.returnValue({
 			args: [
 				'--foo',
 				'--bar',
 				'--baz',
 			],
 		})
-		this.element.model.atomXtermModel.getProfile.and.returnValue({
+		element.model.atomXtermModel.getProfile.and.returnValue({
 			command: 'somecommand',
 		})
 		const expected = {
@@ -238,60 +238,60 @@ describe('XTerminalProfileMenuElement', () => {
 				],
 			},
 		}
-		const actual = this.element.getNewProfileAndChanges()
+		const actual = element.getNewProfileAndChanges()
 		expect(actual).toEqual(expected)
 	})
 
 	it('loadProfile()', () => {
-		spyOn(this.element, 'applyProfileChanges')
-		this.element.loadProfile()
-		expect(this.element.applyProfileChanges).toHaveBeenCalled()
+		spyOn(element, 'applyProfileChanges')
+		element.loadProfile()
+		expect(element.applyProfileChanges).toHaveBeenCalled()
 	})
 
 	it('saveProfile()', () => {
-		spyOn(this.element, 'promptForNewProfileName')
-		this.element.saveProfile()
-		expect(this.element.promptForNewProfileName).toHaveBeenCalled()
+		spyOn(element, 'promptForNewProfileName')
+		element.saveProfile()
+		expect(element.promptForNewProfileName).toHaveBeenCalled()
 	})
 
 	it('deleteProfile() nothing selected', () => {
-		spyOn(this.element, 'promptDelete')
-		this.element.deleteProfile()
-		expect(this.element.promptDelete).not.toHaveBeenCalled()
+		spyOn(element, 'promptDelete')
+		element.deleteProfile()
+		expect(element.promptDelete).not.toHaveBeenCalled()
 	})
 
 	it('deleteProfile() option selected', () => {
-		spyOn(this.element, 'promptDelete')
+		spyOn(element, 'promptDelete')
 		const mock = jasmine.createSpy('mock')
 		mock.options = [{ text: 'foo' }]
 		mock.selectedIndex = 0
-		spyOn(this.element.mainDiv, 'querySelector').and.returnValue(mock)
-		this.element.deleteProfile()
-		expect(this.element.promptDelete).toHaveBeenCalledWith('foo')
+		spyOn(element.mainDiv, 'querySelector').and.returnValue(mock)
+		element.deleteProfile()
+		expect(element.promptDelete).toHaveBeenCalledWith('foo')
 	})
 
 	it('promptDelete()', (done) => {
-		spyOn(this.element.deleteProfileModel, 'promptDelete').and.callFake((newProfile) => {
+		spyOn(element.deleteProfileModel, 'promptDelete').and.callFake((newProfile) => {
 			expect(newProfile).toBe('foo')
 			done()
 		})
-		this.element.promptDelete('foo')
+		element.promptDelete('foo')
 	})
 
 	it('promptForNewProfileName()', (done) => {
-		spyOn(this.element.saveProfileModel, 'promptForNewProfileName').and.callFake((newProfile, profileChanges) => {
+		spyOn(element.saveProfileModel, 'promptForNewProfileName').and.callFake((newProfile, profileChanges) => {
 			expect(newProfile).toBe('foo')
 			expect(profileChanges).toBe('bar')
 			done()
 		})
-		this.element.promptForNewProfileName('foo', 'bar')
+		element.promptForNewProfileName('foo', 'bar')
 	})
 
 	it('setNewMenuSettings()', () => {
-		this.element.setNewMenuSettings(this.element.profilesSingleton.getBaseProfile())
+		element.setNewMenuSettings(element.profilesSingleton.getBaseProfile())
 	})
 
 	it('setNewMenuSettings() clear = true', () => {
-		this.element.setNewMenuSettings(this.element.profilesSingleton.getBaseProfile(), true)
+		element.setNewMenuSettings(element.profilesSingleton.getBaseProfile(), true)
 	})
 })

--- a/spec/profile-menu-model-spec.js
+++ b/spec/profile-menu-model-spec.js
@@ -22,54 +22,54 @@
 import { XTerminalProfileMenuModel } from '../src/profile-menu-model'
 
 describe('XTerminalProfileMenuModel', () => {
-	this.atomXtermModel = null
+	let atomXtermModel
 
 	beforeEach(() => {
-		this.atomXtermModel = jasmine.createSpyObj('atomXtermModel', ['getElement'])
+		atomXtermModel = jasmine.createSpyObj('atomXtermModel', ['getElement'])
 	})
 
 	it('constructor()', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		expect(model).not.toBeUndefined()
 	})
 
 	it('destroy() no element set', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		model.destroy()
 	})
 
 	it('destroy() element set', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		model.element = jasmine.createSpyObj('element', ['destroy'])
 		model.destroy()
 		expect(model.element.destroy).toHaveBeenCalled()
 	})
 
 	it('getTitle()', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		expect(model.getTitle()).toBe('X Terminal Profile Menu')
 	})
 
 	it('getElement()', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		expect(model.getElement()).toBeNull()
 	})
 
 	it('setElement()', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		const mock = jasmine.createSpy('element')
 		model.setElement(mock)
 		expect(model.getElement()).toBe(mock)
 	})
 
 	it('getXTerminalModelElement()', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
 		model.getXTerminalModelElement()
 		expect(model.atomXtermModel.getElement).toHaveBeenCalled()
 	})
 
 	it('getXTerminalModel()', () => {
-		const model = new XTerminalProfileMenuModel(this.atomXtermModel)
-		expect(model.getXTerminalModel()).toBe(this.atomXtermModel)
+		const model = new XTerminalProfileMenuModel(atomXtermModel)
+		expect(model.getXTerminalModel()).toBe(atomXtermModel)
 	})
 })

--- a/spec/profiles-spec.js
+++ b/spec/profiles-spec.js
@@ -237,10 +237,12 @@ describe('XTerminalProfilesSingleton', () => {
 		throw new Error('Unknown key: ' + key)
 	}
 
+	let origAtomConfigGet, disposables, origProfilesConfigPath
+
 	beforeEach(async () => {
-		this.origAtomConfigGet = atom.config.get
-		this.disposables = new CompositeDisposable()
-		this.origProfilesConfigPath = XTerminalProfilesSingleton.instance.profilesConfigPath
+		origAtomConfigGet = atom.config.get
+		disposables = new CompositeDisposable()
+		origProfilesConfigPath = XTerminalProfilesSingleton.instance.profilesConfigPath
 		XTerminalProfilesSingleton.instance.resetBaseProfile()
 		await XTerminalProfilesSingleton.instance.profilesLoadPromise
 		const _path = await temp.mkdir()
@@ -250,10 +252,10 @@ describe('XTerminalProfilesSingleton', () => {
 	})
 
 	afterEach(async () => {
-		atom.config.get = this.origAtomConfigGet
+		atom.config.get = origAtomConfigGet
 		await temp.cleanup()
-		XTerminalProfilesSingleton.instance.profilesConfigPath = this.origProfilesConfigPath
-		this.disposables.dispose()
+		XTerminalProfilesSingleton.instance.profilesConfigPath = origProfilesConfigPath
+		disposables.dispose()
 	})
 
 	it('XTerminalProfilesSingleton cannot be instantiated directly', () => {
@@ -270,7 +272,7 @@ describe('XTerminalProfilesSingleton', () => {
 	it('has proper profiles.json path', () => {
 		const expected = path.join(configDefaults.userDataPath, 'profiles.json')
 		// Need to check to original profiles config path.
-		expect(this.origProfilesConfigPath).toBe(expected)
+		expect(origProfilesConfigPath).toBe(expected)
 	})
 
 	it('sortProfiles()', () => {
@@ -288,7 +290,7 @@ describe('XTerminalProfilesSingleton', () => {
 	})
 
 	it('reloadProfiles()', (done) => {
-		this.disposables.add(XTerminalProfilesSingleton.instance.onDidReloadProfiles((profiles) => {
+		disposables.add(XTerminalProfilesSingleton.instance.onDidReloadProfiles((profiles) => {
 			done()
 		}))
 		XTerminalProfilesSingleton.instance.reloadProfiles()
@@ -296,12 +298,12 @@ describe('XTerminalProfilesSingleton', () => {
 
 	it('onDidReloadProfiles()', () => {
 		// Should just work.
-		this.disposables.add(XTerminalProfilesSingleton.instance.onDidReloadProfiles((profiles) => {}))
+		disposables.add(XTerminalProfilesSingleton.instance.onDidReloadProfiles((profiles) => {}))
 	})
 
 	it('onDidResetBaseProfile()', () => {
 		// Should just work.
-		this.disposables.add(XTerminalProfilesSingleton.instance.onDidResetBaseProfile((baseProfile) => {}))
+		disposables.add(XTerminalProfilesSingleton.instance.onDidResetBaseProfile((baseProfile) => {}))
 	})
 
 	it('updateProfiles()', async () => {

--- a/spec/save-profile-element-spec.js
+++ b/spec/save-profile-element-spec.js
@@ -22,21 +22,21 @@
 import { XTerminalSaveProfileElement } from '../src/save-profile-element'
 
 describe('XTerminalSaveProfileElement', () => {
-	this.model = null
+	let model
 
 	beforeEach(() => {
-		this.model = jasmine.createSpyObj('model', ['setElement'])
+		model = jasmine.createSpyObj('model', ['setElement'])
 	})
 
 	it('initialize()', () => {
 		const element = new XTerminalSaveProfileElement()
-		element.initialize(this.model)
+		element.initialize(model)
 		expect(element.messageDiv.textContent).toBe('Enter new profile name')
 	})
 
 	it('setNewTextbox()', () => {
 		const element = new XTerminalSaveProfileElement()
-		element.initialize(this.model)
+		element.initialize(model)
 		const textbox = jasmine.createSpyObj('textbox', ['getElement'])
 		textbox.getElement.and.returnValue(document.createElement('div'))
 		element.setNewTextbox(textbox)

--- a/spec/save-profile-model-spec.js
+++ b/spec/save-profile-model-spec.js
@@ -23,10 +23,10 @@ import { XTerminalSaveProfileModel } from '../src/save-profile-model'
 import * as atomXtermModelModule from '../src/model'
 
 describe('XTerminalSaveProfileModel', () => {
-	this.atomXtermProfileMenuElement = null
+	let atomXtermProfileMenuElement
 
 	beforeEach(() => {
-		this.atomXtermProfileMenuElement = jasmine.createSpyObj(
+		atomXtermProfileMenuElement = jasmine.createSpyObj(
 			'atomXtermProfileMenuElement',
 			[
 				'applyProfileChanges',
@@ -38,36 +38,36 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('constructor()', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		expect(model).not.toBeNull()
 	})
 
 	it('getTitle()', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		expect(model.getTitle()).toBe('X Terminal Save Profile Model')
 	})
 
 	it('getElement()', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		expect(model.getElement()).toBeNull()
 	})
 
 	it('setElement()', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		const element = jasmine.createSpy('atomXtermSaveProfileElement')
 		model.setElement(element)
 		expect(model.getElement()).toBe(element)
 	})
 
 	it('getTextbox()', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		const mock = jasmine.createSpy('textbox')
 		model.textbox = mock
 		expect(model.getTextbox()).toBe(mock)
 	})
 
 	it('updateProfile()', (done) => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		spyOn(model.profilesSingleton, 'setProfile').and.returnValue(Promise.resolve())
 		model.atomXtermProfileMenuElement.applyProfileChanges.and.callFake((profileChanges) => {
 			expect(profileChanges).toBe('baz')
@@ -77,7 +77,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('confirm() no name given', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.textbox = jasmine.createSpyObj('textbox', ['getText'])
 		model.textbox.getText.and.returnValue('')
 		spyOn(model.profilesSingleton, 'isProfileExists').and.returnValue(Promise.resolve(false))
@@ -86,7 +86,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('confirm() name given does not exist', (done) => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.textbox = jasmine.createSpyObj('textbox', ['getText'])
 		model.textbox.getText.and.returnValue('foo')
 		spyOn(model.profilesSingleton, 'isProfileExists').and.returnValue(Promise.resolve(false))
@@ -100,7 +100,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('confirm() name given exists', (done) => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.textbox = jasmine.createSpyObj('textbox', ['getText'])
 		model.textbox.getText.and.returnValue('foo')
 		spyOn(model.profilesSingleton, 'isProfileExists').and.returnValue(Promise.resolve(true))
@@ -113,7 +113,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('close() panel is not visible', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(false)
 		model.textbox = jasmine.createSpyObj('textbox', ['setText'])
@@ -123,7 +123,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('close() panel is visible profile menu element is not visible', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.textbox = jasmine.createSpyObj('textbox', ['setText'])
@@ -134,7 +134,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('close() panel is visible profile menu element is visible', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.textbox = jasmine.createSpyObj('textbox', ['setText'])
@@ -145,7 +145,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('close() panel is visible profile menu element is visible focusMenuElement = false', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'hide'])
 		model.panel.isVisible.and.returnValue(true)
 		model.textbox = jasmine.createSpyObj('textbox', ['setText'])
@@ -156,7 +156,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('promptForNewProfileName() modal is not visible current item is not XTerminalModel', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'show'])
 		model.panel.isVisible.and.returnValue(false)
 		model.element = jasmine.createSpyObj('element', ['setNewTextbox'])
@@ -166,7 +166,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('promptForNewProfileName() modal is not visible current item is XTerminalModel', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'show'])
 		model.panel.isVisible.and.returnValue(false)
 		model.element = jasmine.createSpyObj('element', ['setNewTextbox'])
@@ -176,7 +176,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('promptForNewProfileName() modal is visible current item is not XTerminalModel', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'show'])
 		model.panel.isVisible.and.returnValue(true)
 		model.element = jasmine.createSpyObj('element', ['setNewTextbox'])
@@ -186,7 +186,7 @@ describe('XTerminalSaveProfileModel', () => {
 	})
 
 	it('promptForNewProfileName() modal is visible current item is XTerminalModel', () => {
-		const model = new XTerminalSaveProfileModel(this.atomXtermProfileMenuElement)
+		const model = new XTerminalSaveProfileModel(atomXtermProfileMenuElement)
 		model.panel = jasmine.createSpyObj('panel', ['isVisible', 'show'])
 		model.panel.isVisible.and.returnValue(true)
 		model.element = jasmine.createSpyObj('element', ['setNewTextbox'])

--- a/spec/x-terminal-spec.js
+++ b/spec/x-terminal-spec.js
@@ -143,4 +143,101 @@ describe('x-terminal', () => {
 			expect(newTerminal.runCommand).toHaveBeenCalledWith('command 2')
 		})
 	})
+
+	describe('close()', () => {
+		let activeTerminal
+		beforeEach(() => {
+			activeTerminal = {
+				element: {
+					initializedPromise: Promise.resolve(),
+				},
+				exit: jasmine.createSpy('activeTerminal.exit'),
+			}
+			spyOn(xTerminalInstance, 'getActiveTerminal').and.returnValue(activeTerminal)
+		})
+
+		it('closes terminal', async () => {
+			await xTerminalInstance.close()
+
+			expect(activeTerminal.exit).toHaveBeenCalled()
+		})
+	})
+
+	describe('restart()', () => {
+		let activeTerminal
+		beforeEach(() => {
+			activeTerminal = {
+				element: {
+					initializedPromise: Promise.resolve(),
+				},
+				restartPtyProcess: jasmine.createSpy('activeTerminal.restartPtyProcess'),
+			}
+			spyOn(xTerminalInstance, 'getActiveTerminal').and.returnValue(activeTerminal)
+		})
+
+		it('restarts terminal', async () => {
+			await xTerminalInstance.restart()
+
+			expect(activeTerminal.restartPtyProcess).toHaveBeenCalled()
+		})
+	})
+
+	describe('copy()', () => {
+		let activeTerminal
+		beforeEach(() => {
+			activeTerminal = {
+				element: {
+					initializedPromise: Promise.resolve(),
+				},
+				copyFromTerminal: jasmine.createSpy('activeTerminal.copy').and.returnValue('copied'),
+			}
+			spyOn(xTerminalInstance, 'getActiveTerminal').and.returnValue(activeTerminal)
+			spyOn(atom.clipboard, 'write')
+		})
+
+		it('copys terminal', async () => {
+			await xTerminalInstance.copy()
+
+			expect(atom.clipboard.write).toHaveBeenCalledWith('copied')
+		})
+	})
+
+	describe('paste()', () => {
+		let activeTerminal
+		beforeEach(() => {
+			activeTerminal = {
+				element: {
+					initializedPromise: Promise.resolve(),
+				},
+				pasteToTerminal: jasmine.createSpy('activeTerminal.paste'),
+			}
+			spyOn(xTerminalInstance, 'getActiveTerminal').and.returnValue(activeTerminal)
+			spyOn(atom.clipboard, 'read').and.returnValue('copied')
+		})
+
+		it('pastes terminal', async () => {
+			await xTerminalInstance.paste()
+
+			expect(activeTerminal.pasteToTerminal).toHaveBeenCalledWith('copied')
+		})
+	})
+
+	describe('clear()', () => {
+		let activeTerminal
+		beforeEach(() => {
+			activeTerminal = {
+				element: {
+					initializedPromise: Promise.resolve(),
+				},
+				clear: jasmine.createSpy('activeTerminal.clear'),
+			}
+			spyOn(xTerminalInstance, 'getActiveTerminal').and.returnValue(activeTerminal)
+		})
+
+		it('clears terminal', async () => {
+			await xTerminalInstance.clear()
+
+			expect(activeTerminal.clear).toHaveBeenCalled()
+		})
+	})
 })

--- a/src/element.js
+++ b/src/element.js
@@ -628,6 +628,12 @@ class XTerminalElementImpl extends HTMLElement {
 		}
 	}
 
+	clear () {
+		if (this.terminal) {
+			return this.terminal.clear()
+		}
+	}
+
 	applyPendingTerminalProfileOptions () {
 		// For any changes involving the xterm.js Terminal object, only apply them
 		// when the terminal is visible.

--- a/src/model.js
+++ b/src/model.js
@@ -232,6 +232,12 @@ class XTerminalModel {
 		this.element.ptyProcess.write(text)
 	}
 
+	clear () {
+		if (this.element) {
+			return this.element.clear()
+		}
+	}
+
 	setActive () {
 		recalculateActive(this.terminals_set, this)
 	}


### PR DESCRIPTION
Add `x-terminal:clear` command to clear the screen and map it to <kbd>Ctrl</kbd> + <kbd>L</kbd> by default.

closes #214